### PR TITLE
feat: Add dark mode toggle

### DIFF
--- a/app/components/common/dark_mode_toggle/component.html.erb
+++ b/app/components/common/dark_mode_toggle/component.html.erb
@@ -1,0 +1,9 @@
+<%= render UI::Button::Component.new(variant: :rounded_outlined, color: :dark, **attrs) do %>
+  <span class="hidden" data-dark-mode-toggle-target="lightModeIcon">
+    <%= dark_mode_icon %>
+  </span>
+
+  <span class="hidden" data-dark-mode-toggle-target="darkModeIcon">
+    <%= light_mode_icon %>
+  </span>
+<% end %>

--- a/app/components/common/dark_mode_toggle/component.rb
+++ b/app/components/common/dark_mode_toggle/component.rb
@@ -1,0 +1,21 @@
+module Common
+  module DarkModeToggle
+    class Component < ApplicationComponent
+      renders_one :light_mode_icon, UI::Icon::Component
+      renders_one :dark_mode_icon, UI::Icon::Component
+
+      def initialize(**user_attrs)
+        super(**user_attrs)
+      end
+
+      def default_attrs
+        {
+          data: {
+            controller: "dark-mode-toggle",
+            action: "dark-mode-toggle#toggle"
+          }
+        }
+      end
+    end
+  end
+end

--- a/app/components/common/dark_mode_toggle/preview.rb
+++ b/app/components/common/dark_mode_toggle/preview.rb
@@ -1,0 +1,12 @@
+module Common
+  module DarkModeToggle
+    class Preview < ViewComponent::Preview
+      def playground
+        render Common::DarkModeToggle::Component.new do |toggle|
+          toggle.with_light_mode_icon("sun")
+          toggle.with_dark_mode_icon("moon")
+        end
+      end
+    end
+  end
+end

--- a/app/javascript/controllers/dark_mode_toggle_controller.js
+++ b/app/javascript/controllers/dark_mode_toggle_controller.js
@@ -1,0 +1,58 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["lightModeIcon", "darkModeIcon"];
+
+  connect() {
+    this.#updateTheme();
+  }
+
+  get theme() {
+    return localStorage.theme;
+  }
+
+  set theme(theme) {
+    localStorage.theme = theme;
+  }
+
+  toggle() {
+    this.theme = this.#isLightTheme() ? "dark" : "light";
+    this.#onThemeChange();
+  }
+
+  #isLightTheme() {
+    return !this.theme || this.theme == "light";
+  }
+
+  #onThemeChange() {
+    this.#updateTheme();
+  }
+
+  #updateTheme() {
+    if (this.#isLightTheme()) {
+      this.#toggleLightMode();
+    } else {
+      this.#toggleDarkMode();
+    }
+  }
+
+  #toggleLightMode() {
+    document.documentElement.classList.remove("dark");
+    this.#showLightModeIcon();
+  }
+
+  #toggleDarkMode() {
+    document.documentElement.classList.add("dark");
+    this.#showDarkModeIcon();
+  }
+
+  #showLightModeIcon() {
+    this.lightModeIconTarget.classList.remove("hidden");
+    this.darkModeIconTarget.classList.add("hidden");
+  }
+
+  #showDarkModeIcon() {
+    this.darkModeIconTarget.classList.remove("hidden");
+    this.lightModeIconTarget.classList.add("hidden");
+  }
+}

--- a/app/javascript/controllers/dark_mode_toggle_controller.js
+++ b/app/javascript/controllers/dark_mode_toggle_controller.js
@@ -7,21 +7,21 @@ export default class extends Controller {
     this.#updateTheme();
   }
 
-  get theme() {
-    return localStorage.theme;
-  }
-
-  set theme(theme) {
-    localStorage.theme = theme;
-  }
-
   toggle() {
-    this.theme = this.#isLightTheme() ? "dark" : "light";
+    this.#theme = this.#isLightTheme() ? "dark" : "light";
     this.#onThemeChange();
   }
 
+  get #theme() {
+    return localStorage.theme;
+  }
+
+  set #theme(theme) {
+    localStorage.theme = theme;
+  }
+
   #isLightTheme() {
-    return !this.theme || this.theme == "light";
+    return !this.#theme || this.#theme == "light";
   }
 
   #onThemeChange() {

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,6 +6,8 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 import FlashController from "./flash_controller"
+import DarkModeToggleController from "./dark_mode_toggle_controller"
 application.register("hello", HelloController)
 application.register("flash", FlashController)
+application.register("dark-mode-toggle", DarkModeToggleController)
 import "./railsui"

--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -17,7 +17,7 @@
     <%= railsui_head %>
   </head>
 
-  <body style="padding: 20px" class="<%= params.dig(:lookbook, :display, :theme) %>">
+  <body style="padding: 20px" class="<%= params.dig(:lookbook, :display, :theme) %> h-full antialiased text-zinc-900 leading-normal selection:bg-primary-100 selection:text-primary-700 dark:bg-zinc-900 bg-white dark:text-zinc-50 dark:selection:bg-zinc-500/40 dark:selection:text-zinc-200">
     <div style="
       margin-left: auto;
       margin-right: auto;

--- a/test/components/common/dark_mode_toggle_component_test.rb
+++ b/test/components/common/dark_mode_toggle_component_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+module Common
+  module DarkModeToggle
+    class ComponentTest < ViewComponent::TestCase
+      test "renders the component" do
+        render_inline(Common::DarkModeToggle::Component.new) do |toggle|
+          toggle.with_light_mode_icon("sun")
+          toggle.with_dark_mode_icon("moon")
+        end
+
+        assert_selector "button"
+        assert_selector "svg", visible: false, count: 2
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implementa um botão para alternar o tema do sistema entre modo escuro e claro:
![image](https://github.com/user-attachments/assets/af1fb778-5b12-4fe7-b364-786608e941dd)
![image](https://github.com/user-attachments/assets/dd014254-da27-4c5a-a7c5-d4b34133848f)
