### PR TITLE
feat: Add a card component

### DIFF
--- a/app/components/ui/card/actions_component.rb
+++ b/app/components/ui/card/actions_component.rb
@@ -1,0 +1,27 @@
+module UI
+  module Card
+    class ActionsComponent < ApplicationComponent
+      style do
+        base do
+          %w[
+            px-3 pt-6 pb-3
+          ]
+        end
+      end
+
+      def initialize(**user_attrs)
+        super(**user_attrs)
+      end
+
+      def call
+        tag.div(content, **attrs)
+      end
+
+      def default_attrs
+        {
+          class: style
+        }
+      end
+    end
+  end
+end

--- a/app/components/ui/card/body_component.rb
+++ b/app/components/ui/card/body_component.rb
@@ -1,0 +1,27 @@
+module UI
+  module Card
+    class BodyComponent < ApplicationComponent
+      style do
+        base do
+          %w[
+            px-3 pt-2 prose prose-zinc dark:prose-invert
+          ]
+        end
+      end
+
+      def initialize(**user_attrs)
+        super(**user_attrs)
+      end
+
+      def call
+        tag.div(content, **attrs)
+      end
+
+      def default_attrs
+        {
+          class: style
+        }
+      end
+    end
+  end
+end

--- a/app/components/ui/card/component.html.erb
+++ b/app/components/ui/card/component.html.erb
@@ -1,0 +1,3 @@
+<%= tag.div(**attrs) do %>
+  <%= content %>
+<% end %>

--- a/app/components/ui/card/component.rb
+++ b/app/components/ui/card/component.rb
@@ -1,0 +1,26 @@
+module UI
+  module Card
+    class Component < ApplicationComponent
+      style do
+        base do
+          %w[
+            border border-zinc-300/90 shadow-sm shadow-zinc-300/20 rounded-lg
+            dark:shadow-zinc-950/50 dark:bg-zinc-800/90
+            dark:border-zinc-600/80 dark:focus:ring-zinc-600/30
+            dark:focus:border-zinc-600
+          ]
+        end
+      end
+
+      def initialize(**user_attrs)
+        super(**user_attrs)
+      end
+
+      def default_attrs
+        {
+          class: style
+        }
+      end
+    end
+  end
+end

--- a/app/components/ui/card/header_component.html.erb
+++ b/app/components/ui/card/header_component.html.erb
@@ -1,6 +1,5 @@
 <%= tag.div(**attrs) do %>
   <%= title %>
   <%= subtitle %>
-
   <%= content %>
 <% end %>

--- a/app/components/ui/card/header_component.html.erb
+++ b/app/components/ui/card/header_component.html.erb
@@ -1,0 +1,6 @@
+<%= tag.div(**attrs) do %>
+  <%= title %>
+  <%= subtitle %>
+
+  <%= content %>
+<% end %>

--- a/app/components/ui/card/header_component.rb
+++ b/app/components/ui/card/header_component.rb
@@ -1,0 +1,26 @@
+module UI
+  module Card
+    class HeaderComponent < ApplicationComponent
+      renders_one :title, HeaderTitleComponent
+      renders_one :subtitle, HeaderSubtitleComponent
+
+      style do
+        base do
+          %w[
+            px-3 pt-3
+          ]
+        end
+      end
+
+      def initialize(**user_attrs)
+        super(**user_attrs)
+      end
+
+      def default_attrs
+        {
+          class: style
+        }
+      end
+    end
+  end
+end

--- a/app/components/ui/card/header_subtitle_component.rb
+++ b/app/components/ui/card/header_subtitle_component.rb
@@ -1,0 +1,27 @@
+module UI
+  module Card
+    class HeaderSubtitleComponent < ApplicationComponent
+      style do
+        base do
+          %w[
+            text-sm text-zinc-500 font-normal dark:text-zinc-400
+          ]
+        end
+      end
+
+      def initialize(**user_attrs)
+        super(**user_attrs)
+      end
+
+      def call
+        tag.h4(content, **attrs)
+      end
+
+      def default_attrs
+        {
+          class: style
+        }
+      end
+    end
+  end
+end

--- a/app/components/ui/card/header_title_component.rb
+++ b/app/components/ui/card/header_title_component.rb
@@ -1,0 +1,27 @@
+module UI
+  module Card
+    class HeaderTitleComponent < ApplicationComponent
+      style do
+        base do
+          %w[
+            text-lg font-normal text-zinc-900 dark:text-zinc-100 font-heading
+          ]
+        end
+      end
+
+      def initialize(**user_attrs)
+        super(**user_attrs)
+      end
+
+      def call
+        tag.h3(content, **attrs)
+      end
+
+      def default_attrs
+        {
+          class: style
+        }
+      end
+    end
+  end
+end

--- a/app/components/ui/card/media_component.html.erb
+++ b/app/components/ui/card/media_component.html.erb
@@ -1,0 +1,3 @@
+<%= tag.div(**wrapper_attrs) do %>
+  <%= image_tag src, **attrs %>
+<% end %>

--- a/app/components/ui/card/media_component.rb
+++ b/app/components/ui/card/media_component.rb
@@ -12,7 +12,7 @@ module UI
       style do
         base do
           %w[
-            rounded h-[174px] w-full object-cover object-center dark:border 
+            rounded h-[174px] w-full object-cover object-center dark:border
             dark:border-zinc-600/80 border-transparent
           ]
         end

--- a/app/components/ui/card/media_component.rb
+++ b/app/components/ui/card/media_component.rb
@@ -1,0 +1,43 @@
+module UI
+  module Card
+    class MediaComponent < ApplicationComponent
+      style :wrapper do
+        base do
+          %w[
+            relative px-3 pt-3
+          ]
+        end
+      end
+
+      style do
+        base do
+          %w[
+            rounded h-[174px] w-full object-cover object-center dark:border 
+            dark:border-zinc-600/80 border-transparent
+          ]
+        end
+      end
+
+      attr_reader :src, :wrapper_attrs
+
+      def initialize(src: nil, wrapper_attrs: {}, **user_attrs)
+        @src = src
+        @wrapper_attrs = AttributeMerger.new(default_wrapper_attrs, wrapper_attrs).merge
+
+        super(**user_attrs)
+      end
+
+      def default_attrs
+        {
+          class: style
+        }
+      end
+
+      def default_wrapper_attrs
+        {
+          class: style(:wrapper)
+        }
+      end
+    end
+  end
+end

--- a/app/components/ui/card/preview.rb
+++ b/app/components/ui/card/preview.rb
@@ -2,15 +2,7 @@ module UI
   module Card
     class Preview < ViewComponent::Preview
       def playground
-        render UI::Card::Component.new do |card|
-          safe_join([
-            card.render(UI::Card::MediaComponent.new(src: "https://picsum.photos/600/600")),
-            card.render(UI::Card::HeaderComponent.new) do |header|
-              header.with_title.with_content("Read 10 books in 2025")
-              header.with_subtitle.with_content("Expanding My World, One Book at a Time")
-            end
-          ])
-        end
+        render_with_template(template: "ui/card/previews/playground")
       end
     end
   end

--- a/app/components/ui/card/preview.rb
+++ b/app/components/ui/card/preview.rb
@@ -1,0 +1,11 @@
+module UI
+  module Card
+    class Preview < ViewComponent::Preview
+      def playground
+        render UI::Card::Component.new do |card|
+          "Card content"
+        end
+      end
+    end
+  end
+end

--- a/app/components/ui/card/preview.rb
+++ b/app/components/ui/card/preview.rb
@@ -3,7 +3,7 @@ module UI
     class Preview < ViewComponent::Preview
       def playground
         render UI::Card::Component.new do |card|
-          "Card content"
+          card.render(UI::Card::MediaComponent.new(src: "https://picsum.photos/600/600"))
         end
       end
     end

--- a/app/components/ui/card/preview.rb
+++ b/app/components/ui/card/preview.rb
@@ -3,7 +3,13 @@ module UI
     class Preview < ViewComponent::Preview
       def playground
         render UI::Card::Component.new do |card|
-          card.render(UI::Card::MediaComponent.new(src: "https://picsum.photos/600/600"))
+          safe_join([
+            card.render(UI::Card::MediaComponent.new(src: "https://picsum.photos/600/600")),
+            card.render(UI::Card::HeaderComponent.new) do |header|
+              header.with_title.with_content("Read 10 books in 2025")
+              header.with_subtitle.with_content("Expanding My World, One Book at a Time")
+            end
+          ])
         end
       end
     end

--- a/app/components/ui/card/previews/playground.html.erb
+++ b/app/components/ui/card/previews/playground.html.erb
@@ -1,0 +1,44 @@
+<%= render UI::Card::Component.new(class: "max-w-sm") do %>
+  <%= render UI::Card::MediaComponent.new(src: "https://picsum.photos/600/600") %>
+
+  <%= render UI::Card::HeaderComponent.new do |header| %>
+    <% header.with_title.with_content("Read 10 books in 2025") %>
+    <% header.with_subtitle.with_content("Expanding My World, One Book at a Time") %>
+  <% end %>
+
+  <%= render UI::Card::ActionsComponent.new do %>
+    <div class="flex items-center">
+      <div class="flex-1 flex items-center gap-4">
+        <div class="flex items-center gap-2">
+          <%= render UI::Icon::Component.new("home-modern", class: "size-5 text-zinc-600 stroke-current dark:text-zinc-300") %>
+          <span class="text-sm text-zinc-600 dark:text-zinc-300">3 Listings</span>
+        </div>
+        <div class="flex items-center gap-2">
+          <%= render UI::Icon::Component.new("arrow-path", class: "size-4 text-zinc-600 stroke-current dark:text-zinc-300") %>
+          <span class="text-sm text-zinc-600 dark:text-zinc-300">Syncing</span>
+        </div>
+      </div>
+
+      <%= render UI::Dropdown::Component.new do |dropdown| %>
+        <% dropdown.with_trigger do %>
+          <%= render UI::Button::Component.new(
+            class: "bg-transparent hover:bg-zinc-50 rounded-lg px-2 py-1 inline-flex 
+                    items-center justify-center border border-transparent 
+                    focus:border-zinc-300/80 focus:bg-white focus:ring-4 
+                    focus:ring-zinc-300/20 transition ease-in-out duration-200 
+                    group dark:hover:bg-zinc-700 dark:focus:bg-zinc-700 
+                    dark:focus:border-zinc-500 dark:focus:ring-zinc-600/70
+                    text-zinc-500 dark:text-zinc-400"
+          ) do |button| %>
+            <% button.with_leading_icon("ellipsis-horizontal") %>
+          <% end %>
+        <% end %>
+
+        <% dropdown.with_item.with_content("Edit goal") %>
+        <% dropdown.with_item.with_content("Update progress") %>
+        <% dropdown.with_divider %>
+        <% dropdown.with_item.with_content("Delete goal") %>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/components/ui/card/previews/playground.html.erb
+++ b/app/components/ui/card/previews/playground.html.erb
@@ -6,6 +6,10 @@
     <% header.with_subtitle.with_content("Expanding My World, One Book at a Time") %>
   <% end %>
 
+  <%= render UI::Card::BodyComponent.new do |header| %>
+    The body goes here
+  <% end %>
+
   <%= render UI::Card::ActionsComponent.new do %>
     <div class="flex items-center">
       <div class="flex-1 flex items-center gap-4">

--- a/test/components/ui/card_component_test.rb
+++ b/test/components/ui/card_component_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+module UI
+  module Card
+    class ComponentTest < ViewComponent::TestCase
+      def test_renders_the_component
+        render_inline(UI::Card::Component.new) do |card|
+          [
+            card.render(UI::Card::MediaComponent.new(src: "http://example.com/image.png")),
+            card.render(UI::Card::HeaderComponent.new) do |header|
+              header.with_title.with_content("Card Title")
+              header.with_subtitle.with_content("Card Subtitle")
+            end,
+            card.render(UI::Card::BodyComponent.new.with_content("Card Body")),
+            "Content"
+          ].join("\n").html_safe
+        end
+
+        assert_selector "img[src='http://example.com/image.png']"
+        assert_text "Card Title"
+        assert_text "Card Subtitle"
+        assert_text "Card Body"
+        assert_text "Content"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implementa um componente card. O card não tem slots, mas aplica composição e possui componentes filhos que podem ser posicionados em qualquer ordem dentro do card. Exemplo:

```erb
<%= render UI::Card::Component.new(class: "max-w-sm") do %>
  <%= render UI::Card::MediaComponent.new(src: "https://picsum.photos/600/600") %>

  <%= render UI::Card::HeaderComponent.new do |header| %>
    <% header.with_title.with_content("Read 10 books in 2025") %>
    <% header.with_subtitle.with_content("Expanding My World, One Book at a Time") %>
  <% end %>
<% end %>
```

![image](https://github.com/user-attachments/assets/31601f72-818e-4007-81b1-785b7e787f99)
![image](https://github.com/user-attachments/assets/4671de53-2b37-4683-8bfd-190238fcb973)

