### PR TITLE
feat: Add an empty state component

### DIFF
--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -10,7 +10,7 @@ class ApplicationComponent < ViewComponent::Base
   end
 
   def call
-    content
+    content.html_safe
   end
 
   def default_attrs

--- a/app/components/ui/empty_state/component.html.erb
+++ b/app/components/ui/empty_state/component.html.erb
@@ -1,0 +1,17 @@
+<%= tag.div(**attrs) do %>
+  <%= icon %>
+
+  <div>
+    <h2 class="text-xl font-semibold font-heading text-zinc-900 dark:text-zinc-100 tracking-tight mb-2">
+      <%= title %>
+    </h2>
+
+    <p class="text-zinc-500 dark:text-zinc-300">
+      <%= description %>
+    </p>
+  </div>
+
+  <div class="pt-4">
+    <%= actions %>
+  </div>
+<% end %>

--- a/app/components/ui/empty_state/component.rb
+++ b/app/components/ui/empty_state/component.rb
@@ -9,18 +9,35 @@ module UI
       style do
         base do
           %w[
-            text-center flex flex-col items-center justify-center space-y-2 py-6 md:py-16
+            text-center flex flex-col items-center justify-center space-y-2
           ]
         end
+
+        variants {
+          narrow {
+            yes { "py-6 md:py-8" }
+            no { "py-6 md:py-16" }
+          }
+        }
+
+        defaults { { narrow: false } }
       end
 
-      def initialize(**user_attrs)
+      attr_reader :narrow
+
+      def initialize(narrow: false, **user_attrs)
+        @narrow = narrow
+
         super(**user_attrs)
+      end
+
+      def narrow?
+        narrow
       end
 
       def default_attrs
         {
-          class: style
+          class: style(narrow: narrow?)
         }
       end
     end

--- a/app/components/ui/empty_state/component.rb
+++ b/app/components/ui/empty_state/component.rb
@@ -1,0 +1,28 @@
+module UI
+  module EmptyState
+    class Component < ApplicationComponent
+      renders_one :icon, UI::Icon::Component
+      renders_one :title, ApplicationComponent
+      renders_one :description, ApplicationComponent
+      renders_one :actions
+
+      style do
+        base do
+          %w[
+            text-center flex flex-col items-center justify-center space-y-2 py-6 md:py-16
+          ]
+        end
+      end
+
+      def initialize(**user_attrs)
+        super(**user_attrs)
+      end
+
+      def default_attrs
+        {
+          class: style
+        }
+      end
+    end
+  end
+end

--- a/app/components/ui/empty_state/preview.rb
+++ b/app/components/ui/empty_state/preview.rb
@@ -1,0 +1,20 @@
+module UI
+  module EmptyState
+    class Preview < ViewComponent::Preview
+      def playground
+        render UI::EmptyState::Component.new do |empty_state|
+          empty_state.with_icon("document", class: "size-8 font-semibold font-heading text-zinc-900 dark:text-zinc-100")
+          empty_state.with_title.with_content("No goals")
+          empty_state.with_description.with_content("No goals found")
+          empty_state.with_actions do
+            empty_state.render UI::Button::Component.new do |button|
+              button.with_leading_icon("plus-circle")
+
+              "Create goal"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/views/goals/_no_goals.html.erb
+++ b/app/views/goals/_no_goals.html.erb
@@ -1,0 +1,7 @@
+<div class="max-w-xl mx-auto">
+  <%= render UI::EmptyState::Component.new do |empty_state| %>
+    <% empty_state.with_icon("light-bulb", class: "size-8 font-semibold font-heading text-zinc-900 dark:text-zinc-100") %>
+    <% empty_state.with_title.with_content(t(".title")) %>
+    <% empty_state.with_description.with_content(t(".description")) %>
+  <% end %>
+</div>

--- a/app/views/goals/_no_goals_found.html.erb
+++ b/app/views/goals/_no_goals_found.html.erb
@@ -1,0 +1,7 @@
+<div class="max-w-xl mx-auto">
+  <%= render UI::EmptyState::Component.new do |empty_state| %>
+    <% empty_state.with_icon("question-mark-circle", class: "size-8 font-semibold font-heading text-zinc-900 dark:text-zinc-100") %>
+    <% empty_state.with_title.with_content(t(".title")) %>
+    <% empty_state.with_description.with_content(t(".description")) %>
+  <% end %>
+</div>

--- a/app/views/goals/index.html.erb
+++ b/app/views/goals/index.html.erb
@@ -25,7 +25,15 @@
 </div>
 
 <%= turbo_frame_tag "search-result" do %>
-  <div class="grid xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 grid-cols-1 gap-6 my-8">
-    <%= render @goals %>
-  </div>
+  <% if @goals.any? %>
+    <div class="grid xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 grid-cols-1 gap-6 my-8">
+      <%= render @goals, cached: true %>
+    </div>
+  <% elsif Goal.any? %>
+    <%= render "no_goals_found" %>
+  <% end %>
+<% end %>
+
+<% if Goal.none? %>
+  <%= render "no_goals" %>
 <% end %>

--- a/config/locales/pt-BR/views/goals.yml
+++ b/config/locales/pt-BR/views/goals.yml
@@ -35,3 +35,9 @@ pt-BR:
       update:
         success: Meta atualizada com sucesso
         error: Não foi possível atualizar a meta
+    no_goals_found:
+      title: Nenhuma meta encontrada
+      description: Ops! Não encontramos nenhum resultado para a sua busca. Tente ajustar os filtros ou buscar por outro termo.
+    no_goals:
+      title: Sem metas ainda? Comece agora!
+      description: Todo grande objetivo começa com um primeiro passo. Crie sua primeira meta e dê o primeiro passo rumo ao seu sucesso!

--- a/test/components/ui/empty_state_component_test.rb
+++ b/test/components/ui/empty_state_component_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+module UI
+  module EmtpyState
+    class ComponentTest < ViewComponent::TestCase
+      test "renders the component" do
+        render_inline (UI::EmptyState::Component.new) do |empty_state|
+          empty_state.with_icon("document", class: "size-8 font-semibold font-heading text-zinc-900 dark:text-zinc-100")
+          empty_state.with_title.with_content("No goals")
+          empty_state.with_description.with_content("No goals found")
+          empty_state.with_actions do
+            empty_state.render UI::Button::Component.new do |button|
+              button.with_leading_icon("plus-circle")
+
+              "Create goal"
+            end
+          end
+        end
+
+        assert_text "No goals"
+        assert_text "No goals found"
+        assert_selector "svg", count: 2
+        assert_selector "button"
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Adiciona o componente `UI::EmptyState::Component` para mostrar mensagens quando uma pesquisa não retorna resultados ou mensagens similares
- Usa o componente empty state na página de metas

![image](https://github.com/user-attachments/assets/a38c7fb0-50e8-4036-bf1f-4fabfa5c4478)
![image](https://github.com/user-attachments/assets/44f14b0d-10de-48b2-b70e-9894cc355942)
