### PR TITLE
feat: Add user reference to goals

### DIFF
--- a/app/controllers/concerns/goal_scoped.rb
+++ b/app/controllers/concerns/goal_scoped.rb
@@ -6,7 +6,7 @@ module GoalScoped
   end
 
   private
-    def set_goal
-      @goal = Goal.find(params[:goal_id])
-    end
+  def set_goal
+    @goal = Current.goals.find(params[:goal_id])
+  end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,3 +1,2 @@
 class DashboardController < ApplicationController
-  skip_before_action :require_authentication
 end

--- a/app/controllers/goals_controller.rb
+++ b/app/controllers/goals_controller.rb
@@ -2,15 +2,15 @@ class GoalsController < DashboardController
   before_action :set_goal, only: %i[ edit update destroy]
 
   def index
-    @goals = Goal.search(params[:search]).order(created_at: :desc)
+    @goals = Current.goals.search(params[:search]).order(created_at: :desc)
   end
 
   def new
-    @goal = Goal.new(start_date: Time.zone.today)
+    @goal = Current.goals.build(start_date: Time.zone.today)
   end
 
   def create
-    @goal = Goal.new(goal_params)
+    @goal = Current.goals.build(goal_params)
 
     if @goal.save
       redirect_to goals_path, notice: t(".success")
@@ -38,7 +38,7 @@ class GoalsController < DashboardController
 
   private
   def set_goal
-    @goal = Goal.find(params[:id])
+    @goal = Current.goals.find(params[:id])
   end
 
   def goal_params

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,4 +1,5 @@
 class Current < ActiveSupport::CurrentAttributes
   attribute :session
   delegate :user, to: :session, allow_nil: true
+  delegate :goals, to: :user, allow_nil: true
 end

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -1,6 +1,8 @@
 class Goal < ApplicationRecord
   enum :status, [ :pending, :completed ], with_model_name: true
 
+  belongs_to :user
+
   validates :title, presence: true
   validates :start_date, presence: true
   validates :current, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   has_secure_password
 
   has_many :sessions, dependent: :destroy
+  has_many :goals, dependent: :destroy
 
   validates :first_name, presence: true
   validates :last_name, presence: true

--- a/bin/setup
+++ b/bin/setup
@@ -24,7 +24,10 @@ FileUtils.chdir APP_ROOT do
   # end
 
   puts "\n== Preparing database =="
-  system! "bin/rails db:prepare"
+  system! "bin/rails db:drop db:prepare"
+
+  puts "\n== Preparing test database =="
+  system! "RAILS_ENV=test bin/rails db:reset"
 
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"

--- a/db/migrate/20250120140023_add_user_ref_to_goals.rb
+++ b/db/migrate/20250120140023_add_user_ref_to_goals.rb
@@ -1,0 +1,5 @@
+class AddUserRefToGoals < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :goals, :user, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_01_19_174659) do
+ActiveRecord::Schema[8.1].define(version: 2025_01_20_140023) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -49,6 +49,8 @@ ActiveRecord::Schema[8.1].define(version: 2025_01_19_174659) do
     t.decimal "target", precision: 10, scale: 2, default: "0.0", null: false
     t.string "title", null: false
     t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["user_id"], name: "index_goals_on_user_id"
   end
 
   create_table "sessions", force: :cascade do |t|
@@ -72,5 +74,6 @@ ActiveRecord::Schema[8.1].define(version: 2025_01_19_174659) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "goals", "users"
   add_foreign_key "sessions", "users"
 end

--- a/test/controllers/goals/update_progresses_controller_test.rb
+++ b/test/controllers/goals/update_progresses_controller_test.rb
@@ -5,6 +5,8 @@ module Goals
     test "new" do
       goal = create(:goal, current: 1, target: 5)
 
+      sign_in goal.user
+
       get edit_goal_update_progress_url(goal), headers: { "Turbo-Frame" => "frame" }
 
       assert_response :success
@@ -12,6 +14,8 @@ module Goals
 
     test "when the request is not a turbo frame request redirects to root_url" do
       goal = create(:goal, current: 1, target: 5)
+
+      sign_in goal.user
 
       get edit_goal_update_progress_url(goal, format: :html)
 
@@ -27,6 +31,8 @@ module Goals
         }
       }
 
+      sign_in goal.user
+
       patch goal_update_progress_url(goal), params: params
 
       goal.reload
@@ -41,6 +47,8 @@ module Goals
           current: 2
         }
       }
+
+      sign_in goal.user
 
       patch goal_update_progress_url(goal), params: params
 

--- a/test/controllers/goals_controller_test.rb
+++ b/test/controllers/goals_controller_test.rb
@@ -2,16 +2,28 @@ require "test_helper"
 
 class GoalsControllerTest < ActionDispatch::IntegrationTest
   test "index" do
+    user = create(:user)
+
+    sign_in user
+
     get goals_url
     assert_response :success
   end
 
   test "new" do
+    user = create(:user)
+
+    sign_in user
+
     get new_goal_url
     assert_response :success
   end
 
   test "can create goal" do
+    user = create(:user)
+
+    sign_in user
+
     assert_difference("Goal.count") do
       post goals_url, params: { goal: attributes_for(:goal) }
     end
@@ -20,6 +32,10 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "cannot create goal" do
+    user = create(:user)
+
+    sign_in user
+
     assert_no_difference("Goal.count") do
       post goals_url, params: { goal: { title: "" } }
     end
@@ -29,12 +45,17 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
 
   test "edit" do
     goal = create(:goal)
+
+    sign_in goal.user
+
     get edit_goal_url(goal)
     assert_response :success
   end
 
   test "when params are valid it updates the goal" do
     goal = create(:goal, title: "Old title")
+
+    sign_in goal.user
 
     patch goal_url(goal), params: { goal: { title: "New title" } }
 
@@ -45,6 +66,8 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
   test "when params are invalid it doesn't update the goal" do
     goal = create(:goal, title: "Old title")
 
+    sign_in goal.user
+
     patch goal_url(goal), params: { goal: { title: nil } }
 
     assert_response :unprocessable_entity
@@ -53,6 +76,8 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
 
   test "destroy" do
     goal = create(:goal)
+
+    sign_in goal.user
 
     assert_difference("Goal.count", -1) do
       delete goal_url(goal)

--- a/test/controllers/homes_controller_test.rb
+++ b/test/controllers/homes_controller_test.rb
@@ -2,6 +2,10 @@ require "test_helper"
 
 class HomesControllerTest < ActionDispatch::IntegrationTest
   test "index" do
+    user = create(:user)
+
+    sign_in user
+
     get home_url
     assert_response :success
   end

--- a/test/factories/goals.rb
+++ b/test/factories/goals.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :goal do
+    association :user
+
     title { "Read 10 books" }
     description { "In 2025, I want to read 10 books." }
     start_date { Time.zone.today }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,6 +13,14 @@ module ActiveSupport
     fixtures :all
 
     # Add more helper methods to be used by all tests here...
+
+    def sign_in(user)
+      session = user.sessions.create!
+      Current.session = session
+      request = ActionDispatch::Request.new(Rails.application.env_config)
+      cookies = request.cookie_jar
+      cookies.signed[:session_id] = { value: session.id, httponly: true, same_site: :lax }
+    end
   end
 end
 


### PR DESCRIPTION
- Adiciona a coluna `user_id` na tabela `goals`
- Atualiza o GoalsController para buscar goals a partir do usuário logado
- Atualiza o concern GoalScoped para buscar goals a partir do usuário logado
- Adiciona o test helper `sign_in` para criar uma session durante testes
- Corrige os testes que quebraram com a mudança do user

> [!NOTE]
> É recomendado rodar um `bin/setup` para que as migrações sejam executadas corretamente