### PR TITLE
refactor: Apply breadcrumb to goals pages

### DIFF
--- a/app/components/ui/breadcrumb/component.rb
+++ b/app/components/ui/breadcrumb/component.rb
@@ -10,7 +10,7 @@ module UI
       end
 
       renders_many :items, types: {
-        link: { renders: UI::Breadcrumb::LinkComponent, as: :link },
+        item: { renders: UI::Breadcrumb::ItemComponent, as: :item },
         separator: { renders: UI::Breadcrumb::SeparatorComponent, as: :separator }
       }
 

--- a/app/components/ui/breadcrumb/item_component.rb
+++ b/app/components/ui/breadcrumb/item_component.rb
@@ -1,11 +1,11 @@
 module UI
   module Breadcrumb
-    class LinkComponent < ApplicationComponent
+    class ItemComponent < ApplicationComponent
       style do
         variants {
           active {
-            yes { %w[text-primary-500 dark:text-primary-500] }
-            no { %w[hover:underline hover:text-zinc-600 dark:hover:text-zinc-400] }
+            yes { %w[text-zinc-700 dark:text-zinc-200] }
+            no { %w[text-primary-500 dark:text-primary-500] }
           }
         }
       end
@@ -19,7 +19,11 @@ module UI
       end
 
       def call
-        link_to(content, href, **attrs)
+        if active
+          tag.div(content, **attrs)
+        else
+          link_to(content, href, **attrs)
+        end
       end
 
       def default_attrs

--- a/app/components/ui/breadcrumb/previews/playground.html.erb
+++ b/app/components/ui/breadcrumb/previews/playground.html.erb
@@ -1,7 +1,7 @@
 <%= render UI::Breadcrumb::Component.new do |breadcrumb| %>
-  <% breadcrumb.with_link(href: "#").with_content("Home") %>
+  <% breadcrumb.with_item(href: "#").with_content("Home") %>
   <% breadcrumb.with_separator %>
-  <% breadcrumb.with_link(href: "#").with_content("Library") %>
+  <% breadcrumb.with_item(href: "#").with_content("Library") %>
   <% breadcrumb.with_separator %>
-  <% breadcrumb.with_link(href: "#", active: true).with_content("Data") %>
+  <% breadcrumb.with_item(href: "#", active: true).with_content("Data") %>
 <% end %>

--- a/app/views/goals/edit.html.erb
+++ b/app/views/goals/edit.html.erb
@@ -1,16 +1,11 @@
 <%= provide(:title, t(".title")) %>
 
 <div class="max-w-2xl mx-auto">
-  <nav class="font-heading text-sm mb-6 text-zinc-700 dark:text-zinc-200">
-    <ul class="flex items-center gap-3">
-      <li class="after:content-['/'] after:relative after:text-zinc-300 after:left-1 dark:after:text-zinc-500">
-        <%= link_to t(".goals"), "#", class: "text-primary-600 hover:text-primary-700 dark:text-primary-500 dark:hover:text-primary-600" %>
-      </li>
-      <li>
-        <p><%= t(".page_title") %></p>
-      </li>
-    </ul>
-  </nav>
+  <%= render UI::Breadcrumb::Component.new do |breadcrumb| %>
+    <% breadcrumb.with_item(href: goals_path) { t(".goals") } %>
+    <% breadcrumb.with_separator %>
+    <% breadcrumb.with_item(active: true) { t(".page_title") } %>
+  <% end %>
 
   <h1 class="mb-6 text-4xl font-semibold font-heading text-zinc-900 dark:text-zinc-100 tracking-tight"><%= t(".page_title") %></h1>
 

--- a/app/views/goals/new.html.erb
+++ b/app/views/goals/new.html.erb
@@ -1,16 +1,11 @@
 <%= provide(:title, t(".title")) %>
 
 <div class="max-w-2xl mx-auto">
-  <nav class="font-heading text-sm mb-6 text-zinc-700 dark:text-zinc-200">
-    <ul class="flex items-center gap-3">
-      <li class="after:content-['/'] after:relative after:text-zinc-300 after:left-1 dark:after:text-zinc-500">
-        <%= link_to t(".goals"), "#", class: "text-primary-600 hover:text-primary-700 dark:text-primary-500 dark:hover:text-primary-600" %>
-      </li>
-      <li>
-        <p><%= t(".page_title") %></p>
-      </li>
-    </ul>
-  </nav>
+  <%= render UI::Breadcrumb::Component.new do |breadcrumb| %>
+    <% breadcrumb.with_item(href: goals_path, active: true) { t(".goals") } %>
+    <% breadcrumb.with_separator %>
+    <% breadcrumb.with_item { t(".page_title") } %>
+  <% end %>
 
   <h1 class="mb-6 text-4xl font-semibold font-heading text-zinc-900 dark:text-zinc-100 tracking-tight"><%= t(".page_title") %></h1>
 

--- a/test/components/ui/breadcrumb_component_test.rb
+++ b/test/components/ui/breadcrumb_component_test.rb
@@ -5,9 +5,9 @@ module UI
     class ComponentTest < ViewComponent::TestCase
       test "renders the component" do
         render_inline(UI::Breadcrumb::Component.new) do |breadcrumb|
-          breadcrumb.with_link(href: "#").with_content("Goals")
+          breadcrumb.with_item(href: "#").with_content("Goals")
           breadcrumb.with_separator
-          breadcrumb.with_link(href: "#").with_content("New goal")
+          breadcrumb.with_item(href: "#").with_content("New goal")
         end
 
         assert_selector "a[href='#']", text: "Goals"


### PR DESCRIPTION
Com o componente Breadcrumb criado, podemos aplicar ele nas páginas de Metas. Além disso, aproveitei para mudar a nomenclatura de slots e estilo do componente.