### PR TITLE
fix: Update breadcrumb item activation for goals new page

### DIFF
--- a/app/views/goals/new.html.erb
+++ b/app/views/goals/new.html.erb
@@ -2,9 +2,9 @@
 
 <div class="max-w-2xl mx-auto">
   <%= render UI::Breadcrumb::Component.new do |breadcrumb| %>
-    <% breadcrumb.with_item(href: goals_path, active: true) { t(".goals") } %>
+    <% breadcrumb.with_item(href: goals_path) { t(".goals") } %>
     <% breadcrumb.with_separator %>
-    <% breadcrumb.with_item { t(".page_title") } %>
+    <% breadcrumb.with_item(active: true) { t(".page_title") } %>
   <% end %>
 
   <h1 class="mb-6 text-4xl font-semibold font-heading text-zinc-900 dark:text-zinc-100 tracking-tight"><%= t(".page_title") %></h1>


### PR DESCRIPTION
Corrigi a ativação do item do breadcrumb da página de criar meta:

Antes:
<img width="245" alt="Captura de Tela 2025-01-21 às 13 11 58" src="https://github.com/user-attachments/assets/624cb6cb-fa33-409d-9451-2f29a514b34e" />

Depois:
<img width="260" alt="Captura de Tela 2025-01-21 às 13 10 50" src="https://github.com/user-attachments/assets/a3092eca-aed7-4bfc-bdac-60fcc71a4af3" />
