### PR TITLE
feat: Add username column to users table

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -8,7 +8,7 @@ class ProfilesController < ApplicationController
 
   private
   def set_user
-    @user = User.find_by(id: params[:id])
+    @user = User.find_by(username: params[:username])
 
     redirect_to root_path if @user.blank?
   end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -12,7 +12,7 @@ class RegistrationsController < ApplicationController
       start_new_session_for(@user)
       redirect_to root_path
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_entity, alert: t(".error")
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,14 +6,30 @@ class User < ApplicationRecord
 
   validates :first_name, presence: true
   validates :last_name, presence: true
+  validates :username, presence: true, uniqueness: { case_sensitive: false }
   validates :email_address, presence: true, uniqueness: true
 
   validates :first_name, length: { maximum: 255 }
   validates :last_name, length: { maximum: 255 }
+  validates :username, length: { maximum: 255 }
 
   normalizes :email_address, with: ->(e) { e.strip.downcase }
 
+  before_validation :set_username, on: :create
+
   def name
     "#{first_name} #{last_name}"
+  end
+
+  private
+  def set_username
+    return if username.present?
+
+    self.username = name.parameterize(separator: ".").first(255)
+
+    if User.exists?(username: self.username)
+      self.username = self.username.first(248)
+      self.username += ".#{SecureRandom.hex(3)}"
+    end
   end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,8 +3,10 @@
     <%= render "shared/logo_color" %>
   <% end %>
 
-  <% header.with_link(href: root_path).with_content(t(".panel")) %>
-  <% header.with_link(href: goals_path).with_content(t(".goals")) %>
+  <% if Current.user.present? %>
+    <% header.with_link(href: root_path).with_content(t(".panel")) %>
+    <% header.with_link(href: goals_path).with_content(t(".goals")) %>
+  <% end %>
 
   <% header.with_item do %>
     <div class="md:mr-4 mr-3">
@@ -20,38 +22,51 @@
     <div>
   <% end %>
 
-  <% header.with_item do %>
-    <div class="flex items-center justify-center">
-      <%= render UI::Dropdown::Component.new(alignment: :right) do |dropdown| %>
-        <% dropdown.with_trigger do %>
-          <div class="flex items-center justify-center">
-            <%= render UI::Button::Component.new(
-              variant: :rounded_outlined, 
-              color: :dark,
-              size: nil,
-              class: "md:w-10 md:h-10 size-12"
-            ) do %>
-              <%= render UI::Avatar::Component.new(
-                src: nil,
+  <% if Current.user.present? %>
+    <% header.with_item do %>
+      <div class="flex items-center justify-center">
+        <%= render UI::Dropdown::Component.new(alignment: :right) do |dropdown| %>
+          <% dropdown.with_trigger do %>
+            <div class="flex items-center justify-center">
+              <%= render UI::Button::Component.new(
+                variant: :rounded_outlined, 
+                color: :dark,
                 size: nil,
                 class: "md:w-10 md:h-10 size-12"
-              ) do |avatar| %>
-                <% avatar.with_placeholder %>
+              ) do %>
+                <%= render UI::Avatar::Component.new(
+                  src: nil,
+                  size: nil,
+                  class: "md:w-10 md:h-10 size-12"
+                ) do |avatar| %>
+                  <% avatar.with_placeholder %>
+                <% end %>
               <% end %>
-            <% end %>
-          </div>
-        <% end %>
+            </div>
+          <% end %>
 
-        <% dropdown.with_item(href: profile_path(Current.user)) do %>
-          <%= t(".my_profile") %>
-        <% end %>
+          <% dropdown.with_item(href: profile_path(Current.user.username)) do %>
+            <%= t(".my_profile") %>
+          <% end %>
 
-        <% dropdown.with_divider %>
+          <% dropdown.with_divider %>
 
-        <% dropdown.with_item(href: session_path, data: { turbo_method: :delete }) do %>
-          <%= t(".logout") %>
-        <% end %>
+          <% dropdown.with_item(href: session_path, data: { turbo_method: :delete }) do %>
+            <%= t(".logout") %>
+          <% end %>
+      </div>
       <% end %>
-    </div>
+    <% end %>
+  <% end %>
+
+  <% if Current.user.blank? %>
+    <% header.with_item do %>
+      <div class="md:mr-4 mr-3">
+        <%= render UI::Button::Component.new(
+          builder: :a,
+          href: new_session_path
+        ).with_content("Entrar") %>
+      <div>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/layouts/profiles.html.erb
+++ b/app/views/layouts/profiles.html.erb
@@ -1,7 +1,5 @@
 <%= provide(:content) do %>
-  <% if Current.user.present? %>
-    <%= render "layouts/header" %>
-  <% end %>
+  <%= render "layouts/header" %>
 
   <% if content_for?(:main) %>
     <% yield :main %>
@@ -37,7 +35,7 @@
             </h2>
 
             <h3 class="font-light text-base text-zinc-700 tracking-normal dark:text-zinc-300 font-heading">
-              @test.test
+              <%= "@#{@user.username}" %>
             </h2>
           </div>
 

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -11,6 +11,18 @@
             </div>
           <% end %>
 
+          <% if notice || alert %>
+            <div class="mb-6">
+              <% if notice %>
+                <%= render UI::Flash::Component.new(type: :notice).with_content(notice) %>
+              <% end %>
+
+              <% if alert %>
+                <%= render UI::Flash::Component.new(type: :alert).with_content(alert) %>
+              <% end %>
+            </div>
+          <% end %>
+
           <h1 class="text-3xl font-semibold font-heading text-zinc-900 dark:text-zinc-100 tracking-tight mb-6"><%= t("layouts.auth.sign_up") %></h1>
 
           <%= render "form" %>

--- a/config/locales/pt-BR/views/registrations.yml
+++ b/config/locales/pt-BR/views/registrations.yml
@@ -5,3 +5,5 @@ pt-BR:
       password_minimum: Deve ter pelo menos 6 caracteres
     new:
       title: Goals | Cadastre-se
+    create:
+      error: Verifique seus dados e tente novamente.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,5 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :profiles, only: %i[show]
-
-  get "/:id", to: "profiles#show"
+  get "/:username", to: "profiles#show", constraints: { username: /[a-zA-Z0-9\.]+/ }, as: :profile
 end

--- a/db/migrate/20250112234157_create_users.rb
+++ b/db/migrate/20250112234157_create_users.rb
@@ -5,9 +5,11 @@ class CreateUsers < ActiveRecord::Migration[8.1]
       t.string :password_digest, null: false
       t.string :first_name, null: false
       t.string :last_name, null: false
+      t.string :username, null: false
 
       t.timestamps
     end
     add_index :users, :email_address, unique: true
+    add_index :users, :username, unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_01_20_140023) do
+ActiveRecord::Schema[8.1].define(version: 2025_01_21_151601) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -69,7 +69,9 @@ ActiveRecord::Schema[8.1].define(version: 2025_01_20_140023) do
     t.string "last_name", default: "", null: false
     t.string "password_digest", null: false
     t.datetime "updated_at", null: false
+    t.string "username", null: false
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
+    t.index ["username"], name: "index_users_on_username", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -6,7 +6,7 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
 
     sign_in user
 
-    get profile_url(user)
+    get profile_url(username: user.username)
 
     assert_response :success
   end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,9 +1,0 @@
-<% password_digest = BCrypt::Password.create("password") %>
-
-one:
-  email_address: one@example.com
-  password_digest: <%= password_digest %>
-
-two:
-  email_address: two@example.com
-  password_digest: <%= password_digest %>

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,6 +1,10 @@
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
+  def setup
+    create(:user)
+  end
+
   should have_many(:sessions)
 
   should validate_presence_of(:first_name)
@@ -10,9 +14,32 @@ class UserTest < ActiveSupport::TestCase
   should validate_length_of(:last_name).is_at_most(255)
 
   should validate_uniqueness_of(:email_address).case_insensitive
+  should validate_uniqueness_of(:username).case_insensitive
 
   test "name" do
     user = User.new(first_name: "John", last_name: "Doe")
-    assert "John Doe", user.name
+    assert_equal "John Doe", user.name
+  end
+
+  test "generates an username when creating a new user" do
+    user = create(:user, first_name: "John", last_name: "Doe")
+    assert_equal "john.doe", user.username
+  end
+
+  test "generates an username with random hex when there is a collision" do
+    create(:user, first_name: "John", last_name: "Doe")
+    user = create(:user, first_name: "John", last_name: "Doe")
+    assert_match /john.doe.[a-z0-9]+{6}/, user.username
+  end
+
+  test "when first_name and last_name are 255 characters, the username gets truncated to 255 characters long" do
+    user = create(:user, first_name: "a" * 255, last_name: "a" * 255)
+    assert_equal 255, user.username.size
+  end
+
+  test "when first_name and last_name are 255 characters and there is a collision, the username gets truncated to 255 characters long" do
+    create(:user, first_name: "a" * 255, last_name: "a" * 255)
+    user = create(:user, first_name: "a" * 255, last_name: "a" * 255)
+    assert_match /a{248}\.[a-z0-9]+{6}/, user.username
   end
 end


### PR DESCRIPTION
- Adiciona a coluna `username`
  - Essa coluna é preenchida durante a criação do usuário usando o `first_name` e `last_name`. Exemplo: John Doe => john.doe
  - Em caso de colisão com um username existente, uma string aleatória hexadecimal é adicionada no final. Exemplo: John Doe => `john.doe.1b56b1`
- Atualiza a página do perfil de usuário
  - Mostra o handle do user baseado no `username`. Exemplo: @john.doe
  - Mostra a header mesmo quando o usuário está deslogado e adiciona um botão `entrar` para redirecionar o usuário para a página de login

![image](https://github.com/user-attachments/assets/e0879644-a6b9-4549-a205-775201e8399a)
