### PR TITLE
feat: Add profile visibility settings

### DIFF
--- a/app/controllers/concerns/user_scoped.rb
+++ b/app/controllers/concerns/user_scoped.rb
@@ -12,6 +12,7 @@ module UserScoped
   end
 
   def require_follow
+    return if Current.user == @user
     return if @user.public_profile?
     return if Current.user&.follows?(@user)
 

--- a/app/controllers/concerns/user_scoped.rb
+++ b/app/controllers/concerns/user_scoped.rb
@@ -3,10 +3,18 @@ module UserScoped
 
   included do
     before_action :set_user
+    before_action :require_follow
   end
 
   private
   def set_user
     @user = User.find_by(username: params[:username])
+  end
+
+  def require_follow
+    return if @user.public_profile?
+    return if Current.user&.follows?(@user)
+
+    redirect_to profile_path(@user.username)
   end
 end

--- a/app/controllers/settings/profiles_controller.rb
+++ b/app/controllers/settings/profiles_controller.rb
@@ -19,7 +19,7 @@ module Settings
 
     def user_params
       params.require(:user)
-            .permit(:avatar, :first_name, :last_name, :username, :email_address, :new_password, :current_password)
+            .permit(:avatar, :first_name, :last_name, :username, :email_address, :new_password, :current_password, :profile_visibility)
     end
   end
 end

--- a/app/models/concerns/followable.rb
+++ b/app/models/concerns/followable.rb
@@ -9,6 +9,8 @@ module Followable
   end
 
   def follows?(user)
+    return false if user.blank?
+
     followees.exists?(id: user.id)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,8 @@ class User < ApplicationRecord
 
   has_secure_password
 
+  enum :profile_visibility, %i[public private], default: :public, suffix: :profile
+
   has_one_attached :avatar do |attachable|
     attachable.variant :thumb, resize_to_fit: [ 256, 256 ], preprocessed: true
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,6 +34,10 @@ class User < ApplicationRecord
     "@#{username}"
   end
 
+  def allowed_to_view_profile?(user)
+    user == self || public_profile? || user&.follows?(self)
+  end
+
   private
   def set_username
     return if username.present?

--- a/app/views/layouts/profiles.html.erb
+++ b/app/views/layouts/profiles.html.erb
@@ -60,37 +60,11 @@
         </div>
       </div>
 
-      <div class="pt-4 lg:pt-6 grid grid-cols-3 gap-24">
-        <div class="col-span-3 lg:col-span-2">
-          <%= render UI::TabNav::Component.new(class: "pb-0") do |tab_nav| %>
-            <% tab_nav.with_tab(
-              href: profile_path(@user.username),
-              active: current_page?(profile_path(@user.username))
-            ) do |tab| %>
-              <% tab.with_title.with_content(t(".nav.activities")) %>
-            <% end %>
-
-            <% tab_nav.with_tab(
-              href: profile_followers_path(@user.username),
-              active: current_page?(profile_followers_path(@user.username))
-            ) do |tab| %>
-              <% tab.with_title.with_content(t(".nav.followers")) %>
-            <% end %>
-
-            <% tab_nav.with_tab do |tab| %>
-              <% tab.with_title.with_content(t(".nav.goals")) %>
-            <% end %>
-          <% end %>
-        </div>
-      </div>
-
-      <div class="grid grid-cols-3 lg:gap-24">
-        <div class="col-span-3 lg:col-span-2 py-4">
-          <%= yield %>
-        </div>
-
-        <%= render "layouts/profiles/sidebar" %>
-      </div>
+      <% if Current.user == @user || @user.public_profile? || Current.user&.follows?(@user) %>
+        <%= render "layouts/profiles/content" %>
+      <% else %>
+        <%= render "layouts/profiles/private" %>
+      <% end %>
     </main>
   <% end %>
 

--- a/app/views/layouts/profiles.html.erb
+++ b/app/views/layouts/profiles.html.erb
@@ -60,7 +60,7 @@
         </div>
       </div>
 
-      <% if Current.user == @user || @user.public_profile? || Current.user&.follows?(@user) %>
+      <% if @user.allowed_to_view_profile?(Current.user) %>
         <%= render "layouts/profiles/content" %>
       <% else %>
         <%= render "layouts/profiles/private" %>

--- a/app/views/layouts/profiles/_content.html.erb
+++ b/app/views/layouts/profiles/_content.html.erb
@@ -1,0 +1,31 @@
+<div class="pt-4 lg:pt-6 grid grid-cols-3 gap-24">
+  <div class="col-span-3 lg:col-span-2">
+    <%= render UI::TabNav::Component.new(class: "pb-0") do |tab_nav| %>
+      <% tab_nav.with_tab(
+        href: profile_path(@user.username),
+        active: current_page?(profile_path(@user.username))
+      ) do |tab| %>
+        <% tab.with_title.with_content(t(".nav.activities")) %>
+      <% end %>
+
+      <% tab_nav.with_tab(
+        href: profile_followers_path(@user.username),
+        active: current_page?(profile_followers_path(@user.username))
+      ) do |tab| %>
+        <% tab.with_title.with_content(t(".nav.followers")) %>
+      <% end %>
+
+      <% tab_nav.with_tab do |tab| %>
+        <% tab.with_title.with_content(t(".nav.goals")) %>
+      <% end %>
+    <% end %>
+  </div>
+</div>
+
+<div class="grid grid-cols-3 lg:gap-24">
+  <div class="col-span-3 lg:col-span-2 py-4">
+    <%= yield %>
+  </div>
+
+  <%= render "layouts/profiles/sidebar" %>
+</div>

--- a/app/views/layouts/profiles/_private.html.erb
+++ b/app/views/layouts/profiles/_private.html.erb
@@ -1,0 +1,17 @@
+<div class="pt-4 lg:pt-6 grid grid-cols-3 gap-24">
+  <div class="col-span-3 lg:col-span-2 border-b border-zinc-200 dark:border-zinc-600"></div>
+</div>
+
+<div class="grid grid-cols-3 lg:gap-24">
+  <div class="col-span-3 lg:col-span-2 py-4">
+    <div class="max-w-xl mx-auto">
+      <%= render UI::EmptyState::Component.new do |empty_state| %>
+        <% empty_state.with_icon("lock-closed", class: "size-8 font-semibold font-heading text-zinc-900 dark:text-zinc-100") %>
+        <% empty_state.with_title.with_content(t(".title")) %>
+        <% empty_state.with_description.with_content(t(".description")) %>
+      <% end %>
+    </div>
+  </div>
+
+  <%= render "layouts/profiles/sidebar" %>
+</div>

--- a/app/views/settings/profiles/_form.html.erb
+++ b/app/views/settings/profiles/_form.html.erb
@@ -67,6 +67,19 @@
     <%= form.error_message :username %>
   <% end %>
 
+  <%= form.form_group :profile_visibility do %>
+    <%= form.label :profile_visibility, nil, class: "form-label-required" %>
+    <%= form.select(
+      :profile_visibility,
+      [
+        [ t("activerecord.attributes.user.profile_visibility.public"), :public ],
+        [ t("activerecord.attributes.user.profile_visibility.private"), :private ]
+      ],
+      required: true
+    ) %>
+    <%= form.error_message :profile_visibility %>
+  <% end %>
+
   <%= form.form_group :new_password do %>
     <%= form.label :new_password %>
     <%= form.password_field(

--- a/config/locales/pt-BR/layouts.yml
+++ b/config/locales/pt-BR/layouts.yml
@@ -19,10 +19,11 @@ pt-BR:
       unfollow: Parar de seguir
       sidebar:
         social_stats: Estatísticas sociais
-      nav:
-        activities: Atividades
-        followers: Seguidores
-        goals: Metas
+      content:
+        nav:
+          activities: Atividades
+          followers: Seguidores
+          goals: Metas
       private:
         title: Perfil privado
         description: Este perfil é privado. Siga este usuário para visualizar o conteúdo.

--- a/config/locales/pt-BR/layouts.yml
+++ b/config/locales/pt-BR/layouts.yml
@@ -23,3 +23,6 @@ pt-BR:
         activities: Atividades
         followers: Seguidores
         goals: Metas
+      private:
+        title: Perfil privado
+        description: Este perfil é privado. Siga este usuário para visualizar o conteúdo.

--- a/config/locales/pt-BR/models/user.yml
+++ b/config/locales/pt-BR/models/user.yml
@@ -11,6 +11,11 @@ pt-BR:
         password_confirmation: Confirmação de senha
         new_password: Senha
         current_password: Senha atual
+        profile_visibility: Visibilidade do perfil
+        profile_visibility:
+          one: Visiblidade do perfil
+          public: Público
+          private: Privado
     errors:
       models:
         user:

--- a/db/migrate/20250125134548_add_profile_visibility_to_users.rb
+++ b/db/migrate/20250125134548_add_profile_visibility_to_users.rb
@@ -1,0 +1,5 @@
+class AddProfileVisibilityToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :profile_visibility, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -87,6 +87,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_01_30_133350) do
     t.string "first_name", default: "", null: false
     t.string "last_name", default: "", null: false
     t.string "password_digest", null: false
+    t.integer "profile_visibility", default: 0
     t.datetime "updated_at", null: false
     t.string "username", null: false
     t.index ["email_address"], name: "index_users_on_email_address", unique: true

--- a/test/controllers/profiles/followers_controller_test.rb
+++ b/test/controllers/profiles/followers_controller_test.rb
@@ -30,6 +30,28 @@ class Profiles::FollowersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "redirects to profile_url if the user profile is private" do
+    user1 = create(:user)
+    user2 = create(:user, profile_visibility: :private)
+
+    get profile_followers_url(user2.username)
+
+    assert_response :redirect
+    assert_redirected_to profile_url(user2.username)
+  end
+
+  test "list followers if the user profile is private but the current user follows them" do
+    user1 = create(:user)
+    user2 = create(:user, profile_visibility: :private)
+    create(:follow, follower_id: user1.id, followee_id: user2.id)
+
+    sign_in user1
+
+    get profile_followers_url(user2.username)
+
+    assert_response :success
+  end
+
   test "unfollows user if current user is the same as user" do
     user1 = create(:user)
     user2 = create(:user)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -110,4 +110,25 @@ class UserTest < ActiveSupport::TestCase
 
     assert_equal "@test.test", user.handle
   end
+
+  test "allowed to view profile if user is themselves" do
+    user = create(:user, profile_visibility: :private)
+
+    assert user.allowed_to_view_profile?(user)
+  end
+
+  test "allowed to view profile if the profile is public" do
+    user = create(:user, profile_visibility: :public)
+    user2 = create(:user)
+
+    assert user.allowed_to_view_profile?(user2)
+  end
+
+  test "allowed to view profile if the user follows the profile" do
+    user1 = create(:user, profile_visibility: :private)
+    user2 = create(:user)
+    user2.follows.create(followee_id: user1.id)
+
+    assert user1.allowed_to_view_profile?(user2)
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -5,6 +5,8 @@ class UserTest < ActiveSupport::TestCase
     create(:user)
   end
 
+  should define_enum_for(:profile_visibility)
+
   should have_many(:sessions)
   should have_many(:goals)
   should have_many(:posts)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -66,6 +66,12 @@ class UserTest < ActiveSupport::TestCase
     assert_not user1.follows?(user2)
   end
 
+  test "follows? returns false if user is nil" do
+    user1 = create(:user)
+
+    assert_not user1.follows?(nil)
+  end
+
   test "returns follow for user" do
     user1 = create(:user)
     user2 = create(:user)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -124,6 +124,12 @@ class UserTest < ActiveSupport::TestCase
     assert user.allowed_to_view_profile?(user2)
   end
 
+  test "allowed to view profile if the profile is public and user is nil" do
+    user = create(:user, profile_visibility: :public)
+
+    assert user.allowed_to_view_profile?(nil)
+  end
+
   test "allowed to view profile if the user follows the profile" do
     user1 = create(:user, profile_visibility: :private)
     user2 = create(:user)


### PR DESCRIPTION
- Adiciona a coluna `profile_visibility` na tabela `users`
- Adiciona o enum `profile_visiblity` no model User
- Mostra um empty state quando o perfil acessado é privado e o usuário logado não segue ele

> [!NOTE]
> Em outros PRs o botão `Seguir` terá um comportamento diferente se o perfil acessado for privado. Nesses casos, ao invés de um criar um novo Follow entre os usuários, uma solicitação para seguir será enviada para o dono do perfil.

![image](https://github.com/user-attachments/assets/23fabc5f-d2c6-4c6a-9bbc-4710d373dde9)
![image](https://github.com/user-attachments/assets/1c572332-dfe5-4756-9eca-9e10603c453c)
