### PR TITLE
feat: Add model FollowRequest

### DIFF
--- a/app/models/follow_request.rb
+++ b/app/models/follow_request.rb
@@ -1,0 +1,21 @@
+class FollowRequest < ApplicationRecord
+  belongs_to :requester, class_name: "User", foreign_key: "requester_id"
+  belongs_to :followee, class_name: "User", foreign_key: "followee_id"
+
+  validates :requester, uniqueness: { scope: :followee }
+  validate :the_requester_is_not_following_themselves
+
+  def accept!
+    transaction do
+      requester.follows.create!(followee_id:)
+      destroy!
+    end
+  end
+
+  private
+  def the_requester_is_not_following_themselves
+    return if requester_id != followee_id
+
+    errors.add(:base, :cannot_follow_themselves)
+  end
+end

--- a/db/migrate/20250125151238_create_follow_requests.rb
+++ b/db/migrate/20250125151238_create_follow_requests.rb
@@ -1,0 +1,12 @@
+class CreateFollowRequests < ActiveRecord::Migration[8.1]
+  def change
+    create_table :follow_requests do |t|
+      t.references :requester, null: false, foreign_key: { to_table: :users }
+      t.references :followee, null: false, foreign_key: { to_table: :users }
+
+      t.timestamps
+    end
+
+    add_index :follow_requests, %i[requester_id followee_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -39,6 +39,16 @@ ActiveRecord::Schema[8.1].define(version: 2025_01_30_133350) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "follow_requests", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "followee_id", null: false
+    t.integer "requester_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["followee_id"], name: "index_follow_requests_on_followee_id"
+    t.index ["requester_id", "followee_id"], name: "index_follow_requests_on_requester_id_and_followee_id", unique: true
+    t.index ["requester_id"], name: "index_follow_requests_on_requester_id"
+  end
+
   create_table "follows", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "followee_id", null: false
@@ -96,6 +106,8 @@ ActiveRecord::Schema[8.1].define(version: 2025_01_30_133350) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "follow_requests", "users", column: "followee_id"
+  add_foreign_key "follow_requests", "users", column: "requester_id"
   add_foreign_key "follows", "users", column: "followee_id"
   add_foreign_key "follows", "users", column: "follower_id"
   add_foreign_key "goals", "users"

--- a/test/factories/follow_requests.rb
+++ b/test/factories/follow_requests.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :follow_request do
+    
+  end
+end

--- a/test/factories/follow_requests.rb
+++ b/test/factories/follow_requests.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :follow_request do
-    
   end
 end

--- a/test/models/follow_request_test.rb
+++ b/test/models/follow_request_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class FollowRequestTest < ActiveSupport::TestCase
+  should belong_to(:requester)
+  should belong_to(:followee)
+
+  test "an user cannot follow themselves" do
+    user = create(:user)
+    request = build(:follow_request, requester_id: user.id, followee_id: user.id)
+
+    assert_not request.valid?
+  end
+
+  test "accept! creates a follow" do
+    user1 = create(:user)
+    user2 = create(:user)
+    request = create(:follow_request, requester_id: user1.id, followee_id: user2.id)
+
+    assert_difference "Follow.count", +1 do
+      request.accept!
+    end
+
+    follow = Follow.last
+
+    assert_equal user1.id, follow.follower_id
+    assert_equal user2.id, follow.followee_id
+  end
+
+  test "accept! destroys the follow request" do
+    user1 = create(:user)
+    user2 = create(:user)
+    request = create(:follow_request, requester_id: user1.id, followee_id: user2.id)
+
+    assert_difference "FollowRequest.count", -1 do
+      request.accept!
+    end
+  end
+end


### PR DESCRIPTION
- Implementa o model `FollowRequest` que será utilizado para criar o sistema de `solicitar para seguir`
- Implementa o método `FollowRequest#accept!` que permite aceitar uma requisição de follow