### PR TITLE
fix: Add Current.user to follower cache key

### DIFF
--- a/app/views/profiles/followers/index.html.erb
+++ b/app/views/profiles/followers/index.html.erb
@@ -1,6 +1,6 @@
 <% if @followers.any? %>
   <ul class="divide-y divide-zinc-200/80 dark:divide-zinc-700">
-    <%= render partial: "follower", collection: @followers, cached: true %>
+    <%= render partial: "follower", collection: @followers, cached: ->(follower) { [Current.user || :guest, follower] } %>
   </ul>
 <% end %>
 


### PR DESCRIPTION
O dropdown de remover seguidor está aparecendo para os visitantes do perfil. Isso acontece porque a lista de seguidores utiliza fragment caching e a chave do partial é o id do seguidor. 

Como o mesmo seguidor pode ser renderizado de duas formas diferentes (com ou sem dropdown) de acordo com quem está visitando o perfil, o visitante pode acessar o perfil e ver o dropdown que deveria aparecer apenas para o dono.

A solução é adicionar o `Current.user` na chave da cache de cada seguidor. Dessa forma, o dono do perfil sempre vai ver o seguidor com o dropdown e os visitantes não terão acesso a ele.

![image](https://github.com/user-attachments/assets/88fea879-495f-44ce-8b81-c17b0427ba58)
