### PR TITLE
feat: Add features components folder

### DIFF
--- a/app/components/common/dark_mode_toggle/component.rb
+++ b/app/components/common/dark_mode_toggle/component.rb
@@ -1,21 +1,19 @@
-module Common
-  module DarkModeToggle
-    class Component < ApplicationComponent
-      renders_one :light_mode_icon, UI::Icon::Component
-      renders_one :dark_mode_icon, UI::Icon::Component
+module DarkModeToggle
+  class Component < ApplicationComponent
+    renders_one :light_mode_icon, UI::Icon::Component
+    renders_one :dark_mode_icon, UI::Icon::Component
 
-      def initialize(**user_attrs)
-        super(**user_attrs)
-      end
+    def initialize(**user_attrs)
+      super(**user_attrs)
+    end
 
-      def default_attrs
-        {
-          data: {
-            controller: "dark-mode-toggle",
-            action: "dark-mode-toggle#toggle"
-          }
+    def default_attrs
+      {
+        data: {
+          controller: "dark-mode-toggle",
+          action: "dark-mode-toggle#toggle"
         }
-      end
+      }
     end
   end
 end

--- a/app/components/common/dark_mode_toggle/preview.rb
+++ b/app/components/common/dark_mode_toggle/preview.rb
@@ -1,11 +1,9 @@
-module Common
-  module DarkModeToggle
-    class Preview < ViewComponent::Preview
-      def playground
-        render Common::DarkModeToggle::Component.new do |toggle|
-          toggle.with_light_mode_icon("sun")
-          toggle.with_dark_mode_icon("moon")
-        end
+module DarkModeToggle
+  class Preview < ViewComponent::Preview
+    def playground
+      render DarkModeToggle::Component.new do |toggle|
+        toggle.with_light_mode_icon("sun")
+        toggle.with_dark_mode_icon("moon")
       end
     end
   end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -10,7 +10,7 @@
 
   <% header.with_item do %>
     <div class="md:mr-4 mr-3">
-      <%= render Common::DarkModeToggle::Component.new(
+      <%= render DarkModeToggle::Component.new(
         variant: :rounded_outlined, 
         color: :dark,
         size: nil,

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,9 @@ module Goals
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
 
+    Rails.autoloaders.main.collapse("#{Rails.root}/app/components/common")
+    Rails.autoloaders.main.collapse("#{Rails.root}/app/components/features")
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/test/components/common/dark_mode_toggle_component_test.rb
+++ b/test/components/common/dark_mode_toggle_component_test.rb
@@ -1,17 +1,15 @@
 require "test_helper"
 
-module Common
-  module DarkModeToggle
-    class ComponentTest < ViewComponent::TestCase
-      test "renders the component" do
-        render_inline(Common::DarkModeToggle::Component.new) do |toggle|
-          toggle.with_light_mode_icon("sun")
-          toggle.with_dark_mode_icon("moon")
-        end
-
-        assert_selector "button"
-        assert_selector "svg", visible: false, count: 2
+module DarkModeToggle
+  class ComponentTest < ViewComponent::TestCase
+    test "renders the component" do
+      render_inline(DarkModeToggle::Component.new) do |toggle|
+        toggle.with_light_mode_icon("sun")
+        toggle.with_dark_mode_icon("moon")
       end
+
+      assert_selector "button"
+      assert_selector "svg", visible: false, count: 2
     end
   end
 end


### PR DESCRIPTION
- Adiciona a pasta `app/components/features` para componentes específicos de um domínio. Ex:
  -  `app/components/goals/card/component.rb`
- Utiliza a opção `collapse` do zeitwerk para não criar os módulos Features e Common
- Remove o módulo Common do componente DarkModeToggle