### PR TITLE
feat: Add Entry::Likes model

### DIFF
--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -3,6 +3,8 @@ class Entry < ApplicationRecord
 
   delegated_type :entryable, types: %w[], dependent: :destroy
 
+  has_many :likes, class_name: "Entry::Like", dependent: :destroy
+
   belongs_to :owner, class_name: "User", foreign_key: :owner_id
 
   validates_associated :entryable

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -1,7 +1,7 @@
 class Entry < ApplicationRecord
   FEED_ENTRIES = %w[ Post ]
 
-  delegated_type :entryable, types: %w[], dependent: :destroy
+  delegated_type :entryable, types: %w[ Post ], dependent: :destroy
 
   has_many :likes, class_name: "Entry::Like", dependent: :destroy
 

--- a/app/models/entry/like.rb
+++ b/app/models/entry/like.rb
@@ -1,0 +1,6 @@
+class Entry::Like < ApplicationRecord
+  belongs_to :entry
+  belongs_to :user
+
+  validates :user, uniqueness: { scope: :entry }
+end

--- a/db/migrate/20250202144844_create_entry_likes.rb
+++ b/db/migrate/20250202144844_create_entry_likes.rb
@@ -1,0 +1,12 @@
+class CreateEntryLikes < ActiveRecord::Migration[8.1]
+  def change
+    create_table :entry_likes do |t|
+      t.references :entry, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :entry_likes, %i[entry_id user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_02_02_140755) do
+ActiveRecord::Schema[8.1].define(version: 2025_02_02_144844) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -47,6 +47,16 @@ ActiveRecord::Schema[8.1].define(version: 2025_02_02_140755) do
     t.datetime "updated_at", null: false
     t.index ["entryable_id", "entryable_type"], name: "index_entries_on_entryable_id_and_entryable_type", unique: true
     t.index ["owner_id"], name: "index_entries_on_owner_id"
+  end
+
+  create_table "entry_likes", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "entry_id", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["entry_id", "user_id"], name: "index_entry_likes_on_entry_id_and_user_id", unique: true
+    t.index ["entry_id"], name: "index_entry_likes_on_entry_id"
+    t.index ["user_id"], name: "index_entry_likes_on_user_id"
   end
 
   create_table "follow_requests", force: :cascade do |t|
@@ -125,6 +135,8 @@ ActiveRecord::Schema[8.1].define(version: 2025_02_02_140755) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "entries", "users", column: "owner_id"
+  add_foreign_key "entry_likes", "entries"
+  add_foreign_key "entry_likes", "users"
   add_foreign_key "follow_requests", "users", column: "followee_id"
   add_foreign_key "follow_requests", "users", column: "requester_id"
   add_foreign_key "follows", "users", column: "followee_id"

--- a/test/factories/entries.rb
+++ b/test/factories/entries.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     trait :post do
       entryable { create(:post) }
     end
+    association :owner, factory: :user
   end
 end

--- a/test/factories/entry/likes.rb
+++ b/test/factories/entry/likes.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :entry_like, class: "Entry::Like" do
+    entry
+    user
+  end
+end

--- a/test/models/entry/like_test.rb
+++ b/test/models/entry/like_test.rb
@@ -4,8 +4,8 @@ class Entry::LikeTest < ActiveSupport::TestCase
   should belong_to(:entry)
   should belong_to(:user)
 
-  should "validates user uniqueness" do
-    entry = create(:entry)
+  test "validates user uniqueness" do
+    entry = create(:entry, :post)
     user = create(:user)
 
     create(:entry_like, entry:, user:)

--- a/test/models/entry/like_test.rb
+++ b/test/models/entry/like_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class Entry::LikeTest < ActiveSupport::TestCase
+  should belong_to(:entry)
+  should belong_to(:user)
+
+  should "validates user uniqueness" do
+    entry = create(:entry)
+    user = create(:user)
+
+    create(:entry_like, entry:, user:)
+
+    like = build(:entry_like, entry:, user:)
+
+    assert_not like.valid?
+    assert_includes like.errors[:user], I18n.t("errors.messages.taken")
+  end
+end

--- a/test/models/entry_test.rb
+++ b/test/models/entry_test.rb
@@ -3,6 +3,8 @@ require "test_helper"
 class EntryTest < ActiveSupport::TestCase
   should belong_to(:owner)
 
+  should have_many(:likes).dependent(:destroy)
+
   test "builds with post" do
     post, entry = Entry.build_with_post(Post.new, owner: User.new)
 


### PR DESCRIPTION
Criei o modelo `Entry::Like` que será responsável pela feature de likes nos posts e comentários do Goals.

O modelo possui os seguintes atributos:
- `entry`
- `user` (o usuário que está curtindo a `Entry`)

Cada combinação de `entry_id` e `user_id` deve ter no máximo uma `Entry:Like`, garantindo que um usuário não possa curtir a mesma `Entry` mais de uma vez.