### PR TITLE
feat: Add the feed controller

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,3 +90,6 @@ gem "tailwind_merge", "0.16.0"
 
 # Centralization of locale data collection for Ruby on Rails [https://github.com/svenfuchs/rails-i18n]
 gem "rails-i18n", "~> 8.0.0"
+
+# "A pagination gem [https://github.com/ddnexus/pagy]"
+gem "pagy", "~> 9.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,6 +261,7 @@ GEM
     nokogiri (1.18.2-x86_64-linux-musl)
       racc (~> 1.4)
     ostruct (0.6.1)
+    pagy (9.3.3)
     parallel (1.26.3)
     parser (3.3.6.0)
       ast (~> 2.4.1)
@@ -459,6 +460,7 @@ DEPENDENCIES
   kamal
   listen (= 3.9.0)
   lookbook (= 2.3.4)
+  pagy (~> 9.3)
   propshaft
   puma (>= 5.0)
   rails!

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,7 @@
 class ApplicationController < ActionController::Base
   include Authentication
+  include Pagy::Backend
+
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
   default_form_builder CustomFormBuilder

--- a/app/controllers/feed_controller.rb
+++ b/app/controllers/feed_controller.rb
@@ -1,0 +1,10 @@
+class FeedController < DashboardController
+  def index
+    @pagy, @entries = pagy(Current.entries.feed)
+
+    respond_to do |format|
+      format.html
+      format.turbo_stream
+    end
+  end
+end

--- a/app/controllers/feed_controller.rb
+++ b/app/controllers/feed_controller.rb
@@ -1,6 +1,6 @@
 class FeedController < DashboardController
   def index
-    @pagy, @entries = pagy(Current.entries.feed)
+    @pagy, @entries = pagy(Current.entries.feed.order(created_at: :desc))
 
     respond_to do |format|
       format.html

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,6 @@
 module ApplicationHelper
+  include Pagy::Frontend
+
   def spacer(amount = 16)
     render "rui/shared/email_spacer", amount: amount
   end

--- a/app/helpers/feed_helper.rb
+++ b/app/helpers/feed_helper.rb
@@ -1,0 +1,2 @@
+module FeedHelper
+end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -1,9 +1,17 @@
 class Entry < ApplicationRecord
+  FEED_ENTRIES = %w[ Post ]
+
   delegated_type :entryable, types: %w[], dependent: :destroy
 
   belongs_to :owner, class_name: "User", foreign_key: :owner_id
 
   validates_associated :entryable
+
+  scope :feed, ->(owner: Current.user) do
+    where(entryable_type: FEED_ENTRIES)
+      .where(owner:)
+      .or(Entry.where(owner: owner.followees))
+  end
 
   def self.build_with_post(post, owner: Current.user)
     [ post, build(entryable: post, owner:) ]

--- a/app/views/entries/entryables/_post.html.erb
+++ b/app/views/entries/entryables/_post.html.erb
@@ -1,0 +1,11 @@
+<% post = entry.entryable %>
+
+<%= render UI::Card::Component.new do |card| %>
+  <%= render UI::Card::HeaderComponent.new do |header| %>
+    <% header.with_title.with_content(post.title) %>
+  <% end %>
+
+  <%= render UI::Card::BodyComponent.new do |header| %>
+    <%= post.body %>
+  <% end %>
+<% end %>

--- a/app/views/feed/_entry.html.erb
+++ b/app/views/feed/_entry.html.erb
@@ -1,0 +1,3 @@
+<% cache([:feed, entry]) do %>
+  <%= render "entries/entryables/#{entry.entryable_name}", entry: %>
+<% end %>

--- a/app/views/feed/_next_page.html.erb
+++ b/app/views/feed/_next_page.html.erb
@@ -1,0 +1,7 @@
+<%= turbo_frame_tag :next_page, src: feed_index_path(format: :turbo_stream, page: pagy.next), loading: :lazy do %>
+  <div class="flex items-center justify-center">
+    <span class="text-zinc-500 dark:text-zinc-300">
+      <%= t(".loading") %>
+    </span>
+  </div>
+<% end %>

--- a/app/views/feed/_no_entries.html.erb
+++ b/app/views/feed/_no_entries.html.erb
@@ -1,0 +1,7 @@
+<div class="max-w-xl mx-auto">
+  <%= render UI::EmptyState::Component.new do |empty_state| %>
+    <% empty_state.with_icon("document", class: "size-8 font-semibold font-heading text-zinc-900 dark:text-zinc-100") %>
+    <% empty_state.with_title.with_content(t(".title")) %>
+    <% empty_state.with_description.with_content(t(".description")) %>
+  <% end %>
+</div>

--- a/app/views/feed/index.html.erb
+++ b/app/views/feed/index.html.erb
@@ -1,0 +1,30 @@
+<%= provide(:title, t(".title")) %>
+
+<div class="max-w-2xl mx-auto">
+  <%= render UI::Breadcrumb::Component.new do |breadcrumb| %>
+    <% breadcrumb.with_item(href: root_path) { t(".panel") } %>
+    <% breadcrumb.with_separator %>
+    <% breadcrumb.with_item(active: true) { t(".page_title") } %>
+  <% end %>
+
+  <h1
+    class="
+      mb-6 text-4xl font-semibold font-heading text-zinc-900 dark:text-zinc-100
+      tracking-tight
+    "
+  >
+    <%= t(".page_title") %>
+  </h1>
+
+  <% if @entries.any? %>
+    <%= turbo_frame_tag :feed, class: "space-y-4" do %>
+      <%= render partial: "entry", collection: @entries %>
+    <% end %>
+
+    <% if @pagy.next %>
+      <%= render partial: "next_page", locals: { pagy: @pagy } %>
+    <% end %>
+  <% else %>
+    <%= render "no_entries" %>
+  <% end %>
+</div>

--- a/app/views/feed/index.turbo_stream.erb
+++ b/app/views/feed/index.turbo_stream.erb
@@ -1,0 +1,9 @@
+<%= turbo_stream.append :feed do %>
+  <%= render partial: "entry", collection: @entries %>
+<% end %>
+
+<%= turbo_stream.replace :next_page do %>
+  <% if @pagy.next %>
+    <%= render partial: "next_page", locals: { pagy: @pagy } %>
+  <% end %>
+<% end %>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,1 @@
+Pagy::DEFAULT[:limit] = 10

--- a/config/locales/pt-BR/views/feed.yml
+++ b/config/locales/pt-BR/views/feed.yml
@@ -1,0 +1,11 @@
+pt-BR:
+  feed:
+    index:
+      title: Goals | Publicações
+      panel: Painel
+      page_title: Publicações
+    no_entries:
+      title: Nenhuma publicação recente disponível
+      description: Siga perfis ou publique algo para ver conteúdos aqui.
+    next_page:
+      loading: Carregando publicações...

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
   namespace :settings do
     resource :profile, only: %i[edit update]
   end
+  resources :feed, only: %i[index]
 
   scope ":username", as: :profile, constraints: { username: /[a-zA-Z0-9\.]+/ } do
     get "/" => "profiles#show"

--- a/test/controllers/feed_controller_test.rb
+++ b/test/controllers/feed_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class FeedControllerTest < ActionDispatch::IntegrationTest
+  test "index" do
+    user = create(:user)
+
+    sign_in user
+
+    get feed_index_url
+
+    assert_response :success
+  end
+end

--- a/test/factories/entries.rb
+++ b/test/factories/entries.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :entry do
-    entryable_type { "MyString" }
-    entryable_id { 1 }
+    trait :post do
+      entryable { create(:post) }
+    end
   end
 end

--- a/test/models/entry_test.rb
+++ b/test/models/entry_test.rb
@@ -9,4 +9,28 @@ class EntryTest < ActiveSupport::TestCase
     assert_instance_of Post, post
     assert_instance_of Entry, entry
   end
+
+  test "feed scope returns the owner and their followee posts" do
+    user1 = create(:user)
+    user2 = create(:user)
+    user3 = create(:user)
+
+    post1 = create(:entry, :post, owner: user1)
+    post2 = create(:entry, :post, owner: user2)
+    post3 = create(:entry, :post, owner: user3)
+
+    # user 1 follows user 2
+    create(:follow, follower: user1, followee: user2)
+
+    assert_equal [ post1, post2 ], Entry.feed(owner: user1)
+  end
+
+  test "feed scope returns entries with type Post" do
+    user = create(:user)
+    post = create(:entry, :post, owner: user)
+
+    create(:entry, entryable_type: User, entryable_id: 1, owner: user)
+
+    assert_equal [ post ], Entry.feed(owner: user)
+  end
 end


### PR DESCRIPTION
Adiciona o controller FeedController para listar posts do usuário e seus seguidores. No PR #79, o feed será adicionado na página Home.

**Mudanças:**
- Adiciona a gem `pagy`
- Adiciona o FeedController
 - Lista as entries do usuário logado
- Adiciona infinite loading na listagem de publicações do FeedController
- Adiciona o scope `feed` em Entry para listar as postagens do feed do usuário logado

> [!NOTE]
> O design dos posts vai ser alterado no PR #79

![image](https://github.com/user-attachments/assets/7af742e1-8ff7-40c8-b5a7-0ba39d780220)
