### PR TITLE
feat: Add image upload to posts form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,3 +96,6 @@ gem "rails-i18n", "~> 8.0.0"
 
 # "A pagination gem [https://github.com/ddnexus/pagy]"
 gem "pagy", "~> 9.3"
+
+# Active Storage Validations is a gem that allows you to add validations for Active Storage attributes [https://github.com/igorkasyanchuk/active_storage_validations]
+gem "active_storage_validations", "2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,12 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    active_storage_validations (2.0.0)
+      activejob (>= 6.1.4)
+      activemodel (>= 6.1.4)
+      activestorage (>= 6.1.4)
+      activesupport (>= 6.1.4)
+      marcel (>= 1.0.3)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
@@ -449,6 +455,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  active_storage_validations (= 2.0)
   bcrypt (~> 3.1.7)
   bootsnap
   brakeman

--- a/app/components/common/image_preview_card/component.html.erb
+++ b/app/components/common/image_preview_card/component.html.erb
@@ -1,0 +1,26 @@
+<%= tag.div(**attrs) do %>
+  <%= render UI::Card::Component.new do |card| %>
+    <%= image %>
+
+    <%= render UI::Card::ActionsComponent.new do %>
+      <div class="flex items-center justify-end gap-2">
+        <%= render UI::Button::Component.new(
+                type: :button,
+                variant: :square,
+                color: :transparent,
+                data: {
+                  action: "click->removal#remove"
+                }
+              ) do |button| %>
+          <% button.with_leading_icon(
+            "trash",
+            class: "text-zinc-500 dark:text-zinc-400 size-6",
+          ) %>
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>
+
+  <%= file_input %>
+  <%= hidden_input %>
+<% end %>

--- a/app/components/common/image_preview_card/component.rb
+++ b/app/components/common/image_preview_card/component.rb
@@ -1,0 +1,16 @@
+module ImagePreviewCard
+  class Component < ApplicationComponent
+    renders_one :image, ImagePreviewCard::ImageComponent
+    renders_one :file_input, ImagePreviewCard::FileInputComponent
+    renders_one :hidden_input, ImagePreviewCard::HiddenInputComponent
+
+    private
+    def default_attrs
+      {
+        data: {
+          controller: "removal"
+        }
+      }
+    end
+  end
+end

--- a/app/components/common/image_preview_card/file_input_component.rb
+++ b/app/components/common/image_preview_card/file_input_component.rb
@@ -1,0 +1,7 @@
+module ImagePreviewCard
+  class FileInputComponent < ApplicationComponent
+    def call
+      tag.input(type: :file, class: "hidden", **attrs)
+    end
+  end
+end

--- a/app/components/common/image_preview_card/hidden_input_component.rb
+++ b/app/components/common/image_preview_card/hidden_input_component.rb
@@ -1,0 +1,7 @@
+module ImagePreviewCard
+  class HiddenInputComponent < ApplicationComponent
+    def call
+      tag.input(type: :hidden, **attrs)
+    end
+  end
+end

--- a/app/components/common/image_preview_card/image_component.rb
+++ b/app/components/common/image_preview_card/image_component.rb
@@ -1,0 +1,14 @@
+module ImagePreviewCard
+  class ImageComponent < ApplicationComponent
+    def call
+      render UI::Card::MediaComponent.new(src: "", **attrs)
+    end
+
+    private
+    def default_attrs
+      {
+        class: "object-contain"
+      }
+    end
+  end
+end

--- a/app/components/ui/button/component.rb
+++ b/app/components/ui/button/component.rb
@@ -23,6 +23,34 @@ module UI
         defaults { { color: :primary, size: :base } }
       end
 
+      style :square do base { %w[btn gap-2] }
+        base do
+          %w[
+            rounded-lg inline-flex items-center justify-center border
+            focus:ring-4 transition ease-in-out duration-200 group",
+          ]
+        end
+
+        variants {
+          color {
+            transparent do
+              %w[
+                bg-transparent hover:bg-zinc-50 border-transparent
+                focus:border-zinc-300/80 focus:bg-white focus:ring-zinc-300/20
+                dark:hover:bg-zinc-700 dark:focus:bg-zinc-700
+                dark:focus:border-zinc-500 dark:focus:ring-zinc-600/70
+              ]
+            end
+          }
+
+          size {
+            base { %w[px-2 py-1 ] }
+          }
+        }
+
+        defaults { { color: :transparent, size: :base } }
+      end
+
       style :rounded do
         base {
           %w[

--- a/app/components/ui/button/preview.rb
+++ b/app/components/ui/button/preview.rb
@@ -3,7 +3,7 @@ module UI
     class Preview < ViewComponent::Preview
       # @param text
       # @param builder select { choices: [ button, a ] }
-      # @param variant select { choices: [ default, rounded] }
+      # @param variant select { choices: [ default, square, rounded, rounded_outlined] }
       # @param color select { choices: [ primary, secondary, dark, light, white, transparent, link ] }
       # @param size select { choices: [ sm, base, lg ] }
       def playground(builder: :button, variant: :default, text: "Default Button", color: :primary, size: :base)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -15,6 +15,6 @@ class PostsController < DashboardController
 
   private
   def post_params
-    params.require(:post).permit(:title, :body)
+    params.require(:post).permit(:title, :body, images: [])
   end
 end

--- a/app/helpers/custom_form_builder.rb
+++ b/app/helpers/custom_form_builder.rb
@@ -98,5 +98,13 @@ class CustomFormBuilder < ActionView::Helpers::FormBuilder
 
   def add_classes(options, classes)
     options[:class] = [ classes.flatten, options[:class] ].compact.join(" ")
+
+    merge_tailwind_classes(options)
+  end
+
+  def merge_tailwind_classes(attributes)
+    return unless attributes[:class].is_a?(String)
+
+    attributes[:class] = TailwindMerge::Merger.new.merge(attributes[:class])
   end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -10,10 +10,14 @@ import DarkModeToggleController from "./dark_mode_toggle_controller"
 import ModalController from "./modal_controller"
 import SumUpdaterController from "./sum_updater_controller"
 import ImagePreviewController from "./image_preview_controller"
+import RemovalController from "./removal_controller"
+import MultipleImagePreviewController from "./multiple_image_preview_controller"
 application.register("hello", HelloController)
 application.register("flash", FlashController)
 application.register("dark-mode-toggle", DarkModeToggleController)
 application.register("modal", ModalController)
 application.register("sum-updater", SumUpdaterController)
 application.register("image-preview", ImagePreviewController)
+application.register("multiple-image-preview", MultipleImagePreviewController)
+application.register("removal", RemovalController)
 import "./railsui"

--- a/app/javascript/controllers/multiple_image_preview_controller.js
+++ b/app/javascript/controllers/multiple_image_preview_controller.js
@@ -1,0 +1,85 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="multiple-image-preview"
+export default class extends Controller { static targets = ["previewTemplate", "previewContainer", "imagePreview"]
+  static values = {
+    directUploadUrl: {
+      type: String
+    },
+    fileInputName: {
+      type: String
+    },
+    acceptedFileTypes: {
+      type: Array,
+      default: []
+    },
+    maxImages: {
+      type: Number,
+      default: null
+    }
+  }
+
+  handleFileChange(e) {
+    e.preventDefault()
+
+    this.#handleFiles(e.target.files)
+  }
+
+  handleDragOver(e) {
+    e.preventDefault()
+  }
+
+  handleFileDrop(e) {
+    e.preventDefault()
+
+    this.#handleFiles(e.dataTransfer.files)
+  }
+
+  #handleFiles(files) {
+    Array.from(files).forEach(file => this.#handleFile(file))
+  }
+
+  #handleFile(file) {
+    if (!this.#canAddImagePreview()) {
+      return
+    }
+
+    this.#addImagePreview(file)
+  }
+
+  #canAddImagePreview() {
+    if (!this.maxImagesValue) {
+      return true
+    }
+
+    return this.imagePreviewTargets.length < this.maxImagesValue
+  }
+
+  #addImagePreview(file) {
+    const preview = this.#createPreview({
+      file,
+      directUploadUrl: this.directUploadUrlValue,
+      inputName: this.fileInputNameValue
+    })
+
+    this.previewContainerTarget.appendChild(preview)
+  }
+
+  #createPreview({ file, directUploadUrl, inputName }) {
+    const clone = this.previewTemplateTarget.content.cloneNode(true)
+
+    const imageSrc = URL.createObjectURL(file)
+    const image = clone.querySelector("img")
+    image.src = imageSrc
+
+    const dataTransfer = new DataTransfer()
+    dataTransfer.items.add(file)
+
+    const fileInput = clone.querySelector("input[type='file']")
+    fileInput.name = inputName
+    fileInput.files = dataTransfer.files
+    fileInput.dataset.directUploadUrl = directUploadUrl
+
+    return clone
+  }
+}

--- a/app/javascript/controllers/removal_controller.js
+++ b/app/javascript/controllers/removal_controller.js
@@ -1,0 +1,8 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="removal"
+export default class extends Controller {
+  remove() {
+    this.element.remove()
+  }
+}

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,10 +1,22 @@
 class Post < ApplicationRecord
   includes Entryable
 
+  has_many_attached :images do |attachable|
+    attachable.variant :large, resize_to_limit: [ 1200, 1200 ], preprocessed: true
+    attachable.variant :medium, resize_to_limit: [ 600, 600 ], preprocessed: true
+  end
+
   belongs_to :goal_progress_change, class_name: "Goal::ProgressChange", optional: true, foreign_key: "goal_progress_change_id"
 
   validates :title, presence: true
   validates :body, presence: true
 
   validates :title, length: { maximum: 60 }
+  validates :images,
+            content_type: {
+              with: %w[image/png image/jpeg image/gif image/webp],
+              message: :content_type
+            },
+            limit: { max: 5, message: :limit },
+            size: { less_than_or_equal_to: 8.megabytes, message: :size }
 end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,4 +1,23 @@
-<%= custom_form_with model: post do |form| %>
+<%= custom_form_with(
+  model: post,
+  data: {
+    controller: "multiple-image-preview",
+    multiple_image_preview_direct_upload_url_value: rails_direct_uploads_url,
+    multiple_image_preview_file_input_name_value: "post[images][]",
+    multiple_image_preview_max_images_value: 5
+  }
+) do |form| %>
+  <template data-multiple-image-preview-target="previewTemplate">
+    <%= render ImagePreviewCard::Component.new(
+      data: {
+        multiple_image_preview_target: "imagePreview"
+      }
+    ) do |preview| %>
+      <% preview.with_image %>
+      <% preview.with_file_input %>
+    <% end %>
+  </template>
+
   <%= form.form_group :title do %>
     <%= form.label :title, nil, class: "form-label-required" %>
     <%= form.text_field :title %>
@@ -11,8 +30,48 @@
     <%= form.error_message :body %>
   <% end %>
 
+  <%= form.form_group :images do %>
+    <%= form.label :images %>
+    <%= form.error_message :images, class: "mt-0" %>
+    <%= render UI::Dropzone::Component.new(
+      class: "mt-3",
+      data: {
+        action: [
+          "dragover->multiple-image-preview#handleDragOver",
+          "drop->multiple-image-preview#handleFileDrop",
+        ].join(" ")
+      }
+    ) do |dropzone| %>
+      <% dropzone.with_file_input(
+        multiple: true,
+        data: {
+          action: "change->multiple-image-preview#handleFileChange",
+        },
+      ) %>
+      <% dropzone.with_description.with_content(t(".allowed_file_types")) %>
+    <% end %>
+  <% end %>
+
+  <%= render partial: "preview_container", locals: { post: } %>
+
   <div class="grid grid-cols-2 gap-6 pt-10">
-    <%= render(UI::Button::Component.new(builder: :a, color: :white, href: home_path, class: "cursor-pointer")) { t(".go_back") } %>
-    <%= form.submit value: submit_text, class: "w-full", data: { disable_with: submit_text } %>
+    <%= render(
+      UI::Button::Component.new(
+        builder: :a,
+        color: :white,
+        href: home_path,
+        class: "cursor-pointer",
+      ),
+    ) do %>
+      <%= t(".go_back") %>
+    <% end %>
+
+    <%= form.submit(
+      value: submit_text,
+      class: "w-full",
+      data: {
+        disable_with: submit_text,
+      },
+    ) %>
   </div>
 <% end %>

--- a/app/views/posts/_preview_container.html.erb
+++ b/app/views/posts/_preview_container.html.erb
@@ -1,0 +1,17 @@
+<%= tag.div(
+    class: "grid grid-cols-2 sm:grid-cols-3 gap-4 justify-start",
+    data: {
+      multiple_image_preview_target: "previewContainer"
+    }
+  ) do %>
+  <% post.images.each do |image| %>
+    <%= render ImagePreviewCard::Component.new(
+      data: {
+        multiple_image_preview_target: "imagePreview"
+      }
+    ) do |preview| %>
+      <% preview.with_image(src: image) %>
+      <% preview.with_hidden_input(name: "post[images][]", value: image.signed_id) %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/config/locales/pt-BR/models/posts.yml
+++ b/config/locales/pt-BR/models/posts.yml
@@ -7,3 +7,12 @@ pt-BR:
         title: Título
         body: Conteúdo
         owner: Autor
+        images: Imagens
+    errors:
+      models:
+        post:
+          attributes:
+            images:
+              content_type: Os formatos de imagens permitidos são JPG, PNG, GIF e WEBP
+              limit: O máximo de imagens por publicação é %{max}
+              size: O tamanho máximo permitido por imagem é %{max}

--- a/config/locales/pt-BR/views/posts.yml
+++ b/config/locales/pt-BR/views/posts.yml
@@ -9,3 +9,4 @@ pt-BR:
       success: Publicação criada com sucesso
     form:
       go_back: Voltar
+      allowed_file_types: PNG, JPG, GIF ou WEBP

--- a/test/components/common/image_preview_card_test.rb
+++ b/test/components/common/image_preview_card_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+module ImagePreviewCard
+  class ComponentTest < ViewComponent::TestCase
+    test "renders the component" do
+      render_inline(ImagePreviewCard::Component.new) do |card|
+        card.with_image
+        card.with_file_input
+        card.with_hidden_input
+      end
+
+      assert_selector "img"
+      assert_selector "input[type='file']"
+      assert_selector "input[type='hidden']", visible: false
+    end
+  end
+end

--- a/test/components/ui/dropzone_component_test.rb
+++ b/test/components/ui/dropzone_component_test.rb
@@ -9,7 +9,7 @@ module UI
           dropzone.with_description.with_content("Dropzone description")
         end
 
-        assert_selector "div"
+        assert_text I18n.t("ui.dropzone.component.click_to_upload")
         assert_selector "input[type='file']"
         assert_text "Dropzone description"
       end

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -22,6 +22,29 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to home_path
   end
 
+  test "can create post with images" do
+    user = create(:user)
+    params = {
+      post: attributes_for(
+        :post,
+        images: [
+          file_fixture_upload("avatar_placeholder.png", "image/png")
+        ]
+      )
+    }
+
+    sign_in user
+
+    assert_difference("Post.count") do
+      post posts_url, params:
+    end
+
+    post = Post.last
+
+    assert_redirected_to home_path
+    assert_equal 1, post.images.count
+  end
+
   test "cannot create post" do
     user = create(:user)
 

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -5,4 +5,8 @@ class PostTest < ActiveSupport::TestCase
   should validate_presence_of(:body)
 
   should validate_length_of(:title).is_at_most(60)
+
+  should validate_content_type_of(:images).allowing("image/png", "image/gif", "image/jpeg", "image/gif")
+  should validate_size_of(:images).less_than_or_equal_to(8.megabytes)
+  should validate_limits_of(:images).max(5)
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,9 +1,13 @@
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
+require "minitest/mock"
+require "active_storage_validations/matchers"
 
 module ActiveSupport
   class TestCase
+    extend ActiveStorageValidations::Matchers
+
     include FactoryBot::Syntax::Methods
 
     # Run tests in parallel with specified workers


### PR DESCRIPTION
- Adicona a gem `active_storage_validations` para validar as imagens do Post
- Adiciona um dropzone no formulário do post
- Adiciona o componente ImagePreviewCard para mostrar o preview de uma imagem

**Formulário de criar post:**
![image](https://github.com/user-attachments/assets/03cf0d46-7e2a-46cd-9e75-f7319d93f974)
