### PR TITLE
feat: Add image upload to progress update posts

### DIFF
--- a/app/controllers/goals/progress_changes/posts_controller.rb
+++ b/app/controllers/goals/progress_changes/posts_controller.rb
@@ -28,7 +28,7 @@ class Goals::ProgressChanges::PostsController < DashboardController
 
   def post_params
     params.require(:post)
-      .permit(:title, :body)
+      .permit(:title, :body, images: [])
       .merge(goal_progress_change: @progress_change)
   end
 end

--- a/app/views/goals/progress_changes/posts/_form.html.erb
+++ b/app/views/goals/progress_changes/posts/_form.html.erb
@@ -1,8 +1,25 @@
-<%= custom_form_with model: [goal, progress_change, post] do |form| %>
+<%= custom_form_with(
+  model: [goal, progress_change, post],
+  data: {
+    controller: "multiple-image-preview",
+    multiple_image_preview_direct_upload_url_value: rails_direct_uploads_url,
+    multiple_image_preview_file_input_name_value: "post[images][]",
+    multiple_image_preview_max_images_value: 5
+  }
+) do |form| %>
+  <template data-multiple-image-preview-target="previewTemplate">
+    <%= render ImagePreviewCard::Component.new(
+      data: {
+        multiple_image_preview_target: "imagePreview"
+      }
+    ) do |preview| %>
+      <% preview.with_image %>
+      <% preview.with_file_input %>
+    <% end %>
+  </template>
+
   <%= form.form_group :progress do %>
-    <%= render Goals::ProgressIndicator::Component.new(
-      progress_change: progress_change,
-    ) %>
+    <%= render Goals::ProgressIndicator::Component.new(progress_change: progress_change) %>
   <% end %>
 
   <%= form.form_group :title do %>
@@ -21,11 +38,35 @@
             ".default_body",
             old_value: strip_zeros(progress_change.old_value),
             new_value: strip_zeros(progress_change.new_value),
-            remaining: strip_zeros(progress_change.remaining)
+            remaining: strip_zeros(progress_change.remaining),
           ),
     ) %>
     <%= form.error_message :body %>
   <% end %>
+
+  <%= form.form_group :images do %>
+    <%= form.label :images %>
+    <%= form.error_message :images, class: "mt-0" %>
+    <%= render UI::Dropzone::Component.new(
+      class: "mt-3",
+      data: {
+        action: [
+          "dragover->multiple-image-preview#handleDragOver",
+          "drop->multiple-image-preview#handleFileDrop",
+        ].join(" ")
+      }
+    ) do |dropzone| %>
+      <% dropzone.with_file_input(
+        multiple: true,
+        data: {
+          action: "change->multiple-image-preview#handleFileChange",
+        },
+      ) %>
+      <% dropzone.with_description.with_content(t(".allowed_file_types")) %>
+    <% end %>
+  <% end %>
+
+  <%= render partial: "posts/preview_container", locals: { post: } %>
 
   <div class="grid grid-cols-2 gap-6 pt-10">
     <%= render(
@@ -36,10 +77,13 @@
         class: "cursor-pointer",
       ),
     ) { t(".go_back") } %>
-    <%= form.submit value: t(".submit"),
-                class: "w-full",
-                data: {
-                  disable_with: t(".submit"),
-                } %>
+
+    <%= form.submit(
+      value: t(".submit"),
+      class: "w-full",
+      data: {
+        disable_with: t(".submit"),
+      },
+    ) %>
   </div>
 <% end %>

--- a/config/locales/pt-BR/views/goals.yml
+++ b/config/locales/pt-BR/views/goals.yml
@@ -56,3 +56,4 @@ pt-BR:
           go_back: Voltar
           submit: Publicar
           default_body: "Atualizei minha meta de %{old_value} para %{new_value}. Faltam %{remaining}."
+          allowed_file_types: PNG, JPG, GIF ou WEBP

--- a/test/controllers/goals/progress_changes/posts_controller_test.rb
+++ b/test/controllers/goals/progress_changes/posts_controller_test.rb
@@ -47,4 +47,30 @@ class Goals::ProgressChanges::PostsControllerTest < ActionDispatch::IntegrationT
 
     assert_response :unprocessable_entity
   end
+
+  test "can create post with images" do
+    user = create(:user)
+    goal = create(:goal, user:)
+    progress_change = create(:goal_progress_change, goal:)
+    params = {
+      post: attributes_for(
+        :post,
+        images: [
+          file_fixture_upload("avatar_placeholder.png", "image/png")
+        ]
+      )
+    }
+
+    sign_in user
+
+    assert_difference("Post.count") do
+      post goal_goal_progress_change_posts_path(goal_id: goal.id, goal_progress_change_id: progress_change.id), params: params
+    end
+
+    post = Post.last
+
+    assert_response :redirect
+    assert_redirected_to home_url
+    assert_equal 1, post.images.count
+  end
 end


### PR DESCRIPTION
Adiciona upload de imagens no formulário de posts de atualização de progresso:

![image](https://github.com/user-attachments/assets/e49eb8b5-52f9-4fdc-9ad0-c47b6d3821ed)
