### PR TITLE
feat: Add create comment

### DIFF
--- a/app/controllers/entries/comments_controller.rb
+++ b/app/controllers/entries/comments_controller.rb
@@ -1,0 +1,37 @@
+class Entries::CommentsController < ApplicationController
+  before_action :ensure_turbo_request, only: %i[index new]
+  before_action :set_entry
+
+  def index
+    @pagy, @comments = pagy(@entry.comments.order(created_at: :desc), limit: 3)
+  end
+
+  def new
+    @comment = @entry.comments.build
+  end
+
+  def create
+    comment = @entry.comments.build(comment_params)
+    @comment, entry = Entry.build_with_comment(comment)
+
+    unless entry.save
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+  def ensure_turbo_request
+    return if turbo_frame_request?
+
+    redirect_to root_path
+  end
+
+  def set_entry
+    @entry = Entry.visible(Current.user)
+                  .find(params[:entry_id])
+  end
+
+  def comment_params
+    params.require(:comment).permit(:body)
+  end
+end

--- a/app/controllers/feed_controller.rb
+++ b/app/controllers/feed_controller.rb
@@ -1,6 +1,10 @@
 class FeedController < DashboardController
   def index
-    @pagy, @entries = pagy(Current.entries.includes(:owner, entryable: :comments).feed.order(created_at: :desc))
+    @entries = Current.entries
+                      .includes(owner: { avatar_attachment: :blob })
+                      .feed
+                      .order(created_at: :desc)
+    @pagy, @entries = pagy(@entries)
 
     respond_to do |format|
       format.html

--- a/app/controllers/feed_controller.rb
+++ b/app/controllers/feed_controller.rb
@@ -1,6 +1,6 @@
 class FeedController < DashboardController
   def index
-    @pagy, @entries = pagy(Current.entries.includes(:owner, :entryable).feed.order(created_at: :desc))
+    @pagy, @entries = pagy(Current.entries.includes(:owner, entryable: :comments).feed.order(created_at: :desc))
 
     respond_to do |format|
       format.html

--- a/app/helpers/posts/comments_helper.rb
+++ b/app/helpers/posts/comments_helper.rb
@@ -1,0 +1,2 @@
+module Posts::CommentsHelper
+end

--- a/app/views/entries/comments/_comment_section.html.erb
+++ b/app/views/entries/comments/_comment_section.html.erb
@@ -1,0 +1,19 @@
+<div class="px-3">
+  <%= turbo_frame_tag dom_id(entry, :comments), class: "block space-y-4 pb-3 empty:pb-0" do %>
+    <% if entry.comments.any? %>
+      <%= render(
+        partial: "entries/entryables/comment",
+        collection: entry.comments.order(created_at: :desc).limit(3),
+        cached: ->(comment) { [Current.user, comment] },
+      ) %>
+    <% end %>
+  <% end %>
+
+  <% if entry.comments.count > 3 %>
+    <%= turbo_frame_tag dom_id(entry, :next_page) do %>
+      <div class="mt-1 pb-3">
+        <%= render partial: "entries/comments/load_more_button", locals: { entry:, page: 2 } %>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/entries/comments/_comment_section.html.erb
+++ b/app/views/entries/comments/_comment_section.html.erb
@@ -3,7 +3,7 @@
     <% if entry.comments.any? %>
       <%= render(
         partial: "entries/entryables/comment",
-        collection: entry.comments.order(created_at: :desc).limit(3),
+        collection: entry.comments.includes(:owner).order(created_at: :desc).limit(3),
         cached: ->(comment) { [Current.user, comment] },
       ) %>
     <% end %>

--- a/app/views/entries/comments/_form.html.erb
+++ b/app/views/entries/comments/_form.html.erb
@@ -1,0 +1,14 @@
+<div>
+  <%= custom_form_with(
+    model: [entry, comment], 
+    class: "w-full"
+  ) do |form| %>
+    <div class="flex items-center gap-2 mb-2 shrink-0">
+      <%= render UI::Avatar::Component.new(src: user.avatar.variant(:thumb), size: :xs) %>
+      <div class="basis-full">
+        <%= form.text_field(:body, placeholder: "Adicionar comentário", autofocus: true) %>
+        <%= form.error_message :body %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/entries/comments/_load_more_button.html.erb
+++ b/app/views/entries/comments/_load_more_button.html.erb
@@ -1,0 +1,14 @@
+<%= link_to(
+  entry_comments_path(entry, page:, format: :turbo_stream),
+  class: "font-heading text-zinc-800 focus:text-primary-600
+          relative font-normal hover:transition hover:duration-300 
+          hover:ease-in-out hover:text-zinc-950 dark:text-white 
+          dark:hover:text-zinc-300 dark:focus:text-white text-sm 
+          inline-flex items-center justify-center gap-2",
+  data: {
+    turbo_stream: true
+  }
+) do %>
+  <%= render UI::Icon::Component.new("arrow-path", class: "size-4") %>
+  <%= t(".load_more_comments") %>
+<% end %>

--- a/app/views/entries/comments/create.turbo_stream.erb
+++ b/app/views/entries/comments/create.turbo_stream.erb
@@ -1,0 +1,11 @@
+<%= turbo_stream.update [@entry, :new_comment] %>
+
+<%= turbo_stream.prepend [@entry, :comments] do %>
+  <%= render(
+    partial: "entries/entryables/comment",
+    locals: {
+      entry: @entry,
+      comment: @comment,
+    },
+  ) %>
+<% end %>

--- a/app/views/entries/comments/index.turbo_stream.erb
+++ b/app/views/entries/comments/index.turbo_stream.erb
@@ -1,0 +1,27 @@
+<% @comments.each do |comment| %>
+  <%= turbo_stream.remove comment %>
+<% end %>
+
+<%= turbo_stream.append dom_id(@entry, :comments) do %>
+  <div class="space-y-4">
+    <%= render(
+      partial: "entries/entryables/comment",
+      collection: @comments,
+      cached: ->(comment) { [Current.user, comment] },
+    ) %>
+  </div>
+<% end %>
+
+<% if @pagy.next %>
+  <%= turbo_stream.update dom_id(@entry, :next_page) do %>
+    <div class="mt-1 pb-3">
+      <%= render partial: "entries/comments/load_more_button",
+      locals: {
+        entry: @entry,
+        page: @pagy.next,
+      } %>
+    </div>
+  <% end %>
+<% else %>
+  <%= turbo_stream.remove dom_id(@entry, :next_page) %>
+<% end %>

--- a/app/views/entries/comments/new.html.erb
+++ b/app/views/entries/comments/new.html.erb
@@ -1,0 +1,12 @@
+<%= turbo_frame_tag dom_id(@entry, :new_comment) do %>
+  <div class="px-3 pb-2">
+    <%= render(
+      partial: "form",
+      locals: {
+        entry: @entry,
+        comment: @comment,
+        user: Current.user,
+      },
+    ) %>
+  </div>
+<% end %>

--- a/app/views/entries/entryables/_comment.html.erb
+++ b/app/views/entries/entryables/_comment.html.erb
@@ -1,0 +1,20 @@
+<%= turbo_frame_tag comment, class: "block" do %>
+  <div>
+    <div class="flex items-start gap-2">
+      <%= render UI::Avatar::Component.new(
+        src: comment.owner.avatar.variant(:thumb),
+        size: :xs,
+      ) %>
+      <div>
+        <div>
+          <p class="font-heading"><%= comment.owner.name %></p>
+          <p class="text-sm text-zinc-500 font-normal dark:text-zinc-400"><%= localize(comment.created_at.to_time, format: :friendly) %></p>
+        </div>
+
+        <div class="mt-1">
+          <%= comment.body %>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/entries/entryables/_comment.html.erb
+++ b/app/views/entries/entryables/_comment.html.erb
@@ -1,13 +1,17 @@
 <%= turbo_frame_tag comment, class: "block" do %>
   <div>
     <div class="flex items-start gap-2">
-      <%= render UI::Avatar::Component.new(
-        src: comment.owner.avatar.variant(:thumb),
-        size: :xs,
-      ) %>
+      <%= link_to profile_path(comment.owner.username), data: { turbo_frame: :_top } do %>
+        <%= render UI::Avatar::Component.new(
+          src: comment.owner.avatar.variant(:thumb),
+          size: :xs,
+        ) %>
+      <% end %>
       <div>
         <div>
-          <p class="font-heading"><%= comment.owner.name %></p>
+          <%= link_to profile_path(comment.owner.username), data: { turbo_frame: :_top } do %>
+            <p class="font-heading"><%= comment.owner.name %></p>
+          <% end %>
           <p class="text-sm text-zinc-500 font-normal dark:text-zinc-400"><%= localize(comment.created_at.to_time, format: :friendly) %></p>
         </div>
 

--- a/app/views/entries/entryables/_post.html.erb
+++ b/app/views/entries/entryables/_post.html.erb
@@ -78,15 +78,30 @@
         <%= custom_form_with(
             url: entry_like_path(entry),
             method: entry.liked? ? :delete : :post,
-            id: dom_id(entry, :like_button)
+            id: dom_id(entry, :like_button),
+            class: "inline-flex items-center justify-center"
           ) do %>
           <%= render LikeButton::Component.new(type: :submit, liked: entry.liked?) %>
         <% end %>
 
-        <%= render(UI::Button::Component.new(builder: :button, variant: :rounded, color: :transparent, size: :sm)) do |button| %>
+        <%= render UI::Button::Component.new(
+          builder: :a, 
+          href: new_entry_comment_path(entry), 
+          variant: :rounded, 
+          color: :transparent, 
+          size: :sm,
+          data: {
+            turbo: true,
+            turbo_frame: dom_id(entry, :new_comment)
+          }
+        ) do |button| %>
           <% button.with_trailing_icon("chat-bubble-oval-left") %>
         <% end %>
       </div>
     </div>
   <% end %>
+
+  <%= turbo_frame_tag dom_id(entry, :new_comment) %>
+
+  <%= render partial: "entries/comments/comment_section", locals: { entry: } %>
 <% end %>

--- a/app/views/entries/likes/_update_likes.turbo_stream.erb
+++ b/app/views/entries/likes/_update_likes.turbo_stream.erb
@@ -5,7 +5,8 @@
       id: dom_id(entry, :like_button),
       data: {
         turbo: true
-      }
+      },
+      class: "inline-flex items-center justify-center"
     ) do %>
     <%= render LikeButton::Component.new(type: :submit, liked: like.persisted?) %>
   <% end %>

--- a/config/locales/pt-BR/views/entries.yml
+++ b/config/locales/pt-BR/views/entries.yml
@@ -4,3 +4,6 @@ pt-BR:
       post:
         likes: "%{count} kudos"
     likes: "%{count} kudos"
+    comments:
+      load_more_button:
+        load_more_comments: Carregar mais comentários

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
   resources :entries, only: %i[] do
     scope module: :entries do
       resource :like, only: %i[create destroy]
+      resources :comments, only: %i[index new create]
     end
   end
   resources :follows, only: %i[create destroy]

--- a/test/controllers/posts/comments_controller_test.rb
+++ b/test/controllers/posts/comments_controller_test.rb
@@ -1,8 +1,8 @@
 require "test_helper"
 
 class Posts::CommentsControllerTest < ActionDispatch::IntegrationTest
-  test "new returns a success response if the entry belongs to the current user" do
-    user = create(:user)
+  test "new returns a success response if the current user owns the entry" do
+    user = create(:user, profile_visibility: :private)
     entry = create(:entry, :post, owner: user)
 
     sign_in user
@@ -12,9 +12,21 @@ class Posts::CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "new returns a success response if the entry belongs to any of the current users's followees" do
+  test "new returns a success response if the entry owner's profile is public" do
     user1 = create(:user)
-    user2 = create(:user)
+    user2 = create(:user, profile_visibility: :public)
+    entry = create(:entry, :post, owner: user2)
+
+    sign_in user1
+
+    get new_entry_comment_url(entry), headers: { "Turbo-Frame" => "frame" }
+
+    assert_response :success
+  end
+
+  test "new returns a success response if the current user follows the entry owner" do
+    user1 = create(:user)
+    user2 = create(:user, profile_visibility: :private)
     entry = create(:entry, :post, owner: user2)
     create(:follow, follower: user1, followee: user2)
 
@@ -25,32 +37,21 @@ class Posts::CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "new returns not found response if the entry does not belong to current user" do
-    user = create(:user)
-    entry = create(:entry, :post)
-
-    sign_in user
-
-    get new_entry_comment_url(entry), headers: { "Turbo-Frame" => "frame" }
-
-    assert_response :not_found
-  end
-
-  test "new returns not found response if the entry does not belong to current user's followees" do
+  test "new redirects to root_url if the entry owner's profile is private" do
     user1 = create(:user)
-    user2 = create(:user)
-    entry = create(:entry, :post)
-    create(:follow, follower: user1, followee: user2)
+    user2 = create(:user, profile_visibility: :private)
+    entry = create(:entry, :post, owner: user2)
 
     sign_in user1
 
     get new_entry_comment_url(entry), headers: { "Turbo-Frame" => "frame" }
 
-    assert_response :not_found
+    assert_response :redirect
+    assert_redirected_to root_url
   end
 
-  test "index returns a success response if the entry belongs to the current user" do
-    user = create(:user)
+  test "index returns a success response if the current user owns the entry" do
+    user = create(:user, profile_visibility: :private)
     entry = create(:entry, :post, owner: user)
 
     sign_in user
@@ -60,9 +61,21 @@ class Posts::CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "index returns a success response if the entry belongs to any of the current users's followees" do
+  test "index returns a success response if the entry owner's profile is public" do
     user1 = create(:user)
-    user2 = create(:user)
+    user2 = create(:user, profile_visibility: :public)
+    entry = create(:entry, :post, owner: user2)
+
+    sign_in user1
+
+    get entry_comments_url(entry, format: :turbo_stream), headers: { "Turbo-Frame" => "frame" }
+
+    assert_response :success
+  end
+
+  test "index returns a success response if the current user follows the entry owner" do
+    user1 = create(:user)
+    user2 = create(:user, profile_visibility: :private)
     entry = create(:entry, :post, owner: user2)
     create(:follow, follower: user1, followee: user2)
 
@@ -73,31 +86,20 @@ class Posts::CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "index returns not found response if the entry does not belong to current user" do
-    user = create(:user)
-    entry = create(:entry, :post)
-
-    sign_in user
-
-    get entry_comments_url(entry, format: :turbo_stream), headers: { "Turbo-Frame" => "frame" }
-
-    assert_response :not_found
-  end
-
-  test "index returns not found response if the entry does not belong to current user's followees" do
+  test "index redirects to root_url if the entry owner's profile is private" do
     user1 = create(:user)
-    user2 = create(:user)
-    entry = create(:entry, :post)
-    create(:follow, follower: user1, followee: user2)
+    user2 = create(:user, profile_visibility: :private)
+    entry = create(:entry, :post, owner: user2)
 
     sign_in user1
 
     get entry_comments_url(entry, format: :turbo_stream), headers: { "Turbo-Frame" => "frame" }
 
-    assert_response :not_found
+    assert_response :redirect
+    assert_redirected_to root_url
   end
 
-  test "creates a comment for the current user given an entry" do
+  test "the entry owner can create a comment" do
     user = create(:user)
     entry = create(:entry, :post, owner: user)
     params = {
@@ -106,46 +108,85 @@ class Posts::CommentsControllerTest < ActionDispatch::IntegrationTest
 
     sign_in user
 
-    post entry_comments_url(entry, format: :turbo_stream), headers: { "Turbo-Frame" => "frame" }, params: params
+    assert_difference -> { entry.comments.count } do
+      post entry_comments_url(entry, format: :turbo_stream), params: params
+    end
 
     assert_response :success
-
-    comment = Comment.last
-
-    assert_equal comment.owner, user
   end
 
-  test "creates a comment for the current user followee given an entry" do
+  test "the current user can comment on follower entries" do
     user1 = create(:user)
     user2 = create(:user)
     entry = create(:entry, :post, owner: user2)
+
     create(:follow, follower: user1, followee: user2)
+
     params = {
       comment: attributes_for(:comment)
     }
 
     sign_in user1
 
-    post entry_comments_url(entry, format: :turbo_stream), headers: { "Turbo-Frame" => "frame" }, params: params
+    assert_difference -> { entry.comments.count } do
+      post entry_comments_url(entry, format: :turbo_stream), params: params
+    end
 
     assert_response :success
-
-    comment = Comment.last
-
-    assert_equal comment.owner, user2
   end
 
-  test "create returns a not found response when the current user has no access to a given entry" do
-    user = create(:user)
-    entry = create(:entry, :post)
+  test "the current user can comment on public entries" do
+    user1 = create(:user)
+    user2 = create(:user, profile_visibility: :public)
+    entry = create(:entry, :post, owner: user2)
+
     params = {
       comment: attributes_for(:comment)
     }
 
-    sign_in user
+    sign_in user1
 
-    post entry_comments_url(entry, format: :turbo_stream), headers: { "Turbo-Frame" => "frame" }, params: params
+    assert_difference -> { entry.comments.count } do
+      post entry_comments_url(entry, format: :turbo_stream), params: params
+    end
 
-    assert_response :not_found
+    assert_response :success
+  end
+
+  test "the current user can't comment on private entries" do
+    user1 = create(:user)
+    user2 = create(:user, profile_visibility: :private)
+    entry = create(:entry, :post, owner: user2)
+
+    params = {
+      comment: attributes_for(:comment)
+    }
+
+    sign_in user1
+
+    assert_no_difference -> { entry.comments.count } do
+      post entry_comments_url(entry, format: :turbo_stream), params: params
+    end
+
+    assert_response :redirect
+    assert_redirected_to root_url
+  end
+
+  test "the current user can on entries from users they don't follow" do
+    user1 = create(:user)
+    user2 = create(:user)
+    entry = create(:entry, :post, owner: user2)
+
+    params = {
+      comment: attributes_for(:comment)
+    }
+
+    sign_in user1
+
+    assert_difference -> { entry.comments.count } do
+      post entry_comments_url(entry, format: :turbo_stream), params: params
+    end
+
+    assert_response :success
   end
 end

--- a/test/controllers/posts/comments_controller_test.rb
+++ b/test/controllers/posts/comments_controller_test.rb
@@ -1,0 +1,151 @@
+require "test_helper"
+
+class Posts::CommentsControllerTest < ActionDispatch::IntegrationTest
+  test "new returns a success response if the entry belongs to the current user" do
+    user = create(:user)
+    entry = create(:entry, :post, owner: user)
+
+    sign_in user
+
+    get new_entry_comment_url(entry), headers: { "Turbo-Frame" => "frame" }
+
+    assert_response :success
+  end
+
+  test "new returns a success response if the entry belongs to any of the current users's followees" do
+    user1 = create(:user)
+    user2 = create(:user)
+    entry = create(:entry, :post, owner: user2)
+    create(:follow, follower: user1, followee: user2)
+
+    sign_in user1
+
+    get new_entry_comment_url(entry), headers: { "Turbo-Frame" => "frame" }
+
+    assert_response :success
+  end
+
+  test "new returns not found response if the entry does not belong to current user" do
+    user = create(:user)
+    entry = create(:entry, :post)
+
+    sign_in user
+
+    get new_entry_comment_url(entry), headers: { "Turbo-Frame" => "frame" }
+
+    assert_response :not_found
+  end
+
+  test "new returns not found response if the entry does not belong to current user's followees" do
+    user1 = create(:user)
+    user2 = create(:user)
+    entry = create(:entry, :post)
+    create(:follow, follower: user1, followee: user2)
+
+    sign_in user1
+
+    get new_entry_comment_url(entry), headers: { "Turbo-Frame" => "frame" }
+
+    assert_response :not_found
+  end
+
+  test "index returns a success response if the entry belongs to the current user" do
+    user = create(:user)
+    entry = create(:entry, :post, owner: user)
+
+    sign_in user
+
+    get entry_comments_url(entry, format: :turbo_stream), headers: { "Turbo-Frame" => "frame" }
+
+    assert_response :success
+  end
+
+  test "index returns a success response if the entry belongs to any of the current users's followees" do
+    user1 = create(:user)
+    user2 = create(:user)
+    entry = create(:entry, :post, owner: user2)
+    create(:follow, follower: user1, followee: user2)
+
+    sign_in user1
+
+    get entry_comments_url(entry, format: :turbo_stream), headers: { "Turbo-Frame" => "frame" }
+
+    assert_response :success
+  end
+
+  test "index returns not found response if the entry does not belong to current user" do
+    user = create(:user)
+    entry = create(:entry, :post)
+
+    sign_in user
+
+    get entry_comments_url(entry, format: :turbo_stream), headers: { "Turbo-Frame" => "frame" }
+
+    assert_response :not_found
+  end
+
+  test "index returns not found response if the entry does not belong to current user's followees" do
+    user1 = create(:user)
+    user2 = create(:user)
+    entry = create(:entry, :post)
+    create(:follow, follower: user1, followee: user2)
+
+    sign_in user1
+
+    get entry_comments_url(entry, format: :turbo_stream), headers: { "Turbo-Frame" => "frame" }
+
+    assert_response :not_found
+  end
+
+  test "creates a comment for the current user given an entry" do
+    user = create(:user)
+    entry = create(:entry, :post, owner: user)
+    params = {
+      comment: attributes_for(:comment)
+    }
+
+    sign_in user
+
+    post entry_comments_url(entry, format: :turbo_stream), headers: { "Turbo-Frame" => "frame" }, params: params
+
+    assert_response :success
+
+    comment = Comment.last
+
+    assert_equal comment.owner, user
+  end
+
+  test "creates a comment for the current user followee given an entry" do
+    user1 = create(:user)
+    user2 = create(:user)
+    entry = create(:entry, :post, owner: user2)
+    create(:follow, follower: user1, followee: user2)
+    params = {
+      comment: attributes_for(:comment)
+    }
+
+    sign_in user1
+
+    post entry_comments_url(entry, format: :turbo_stream), headers: { "Turbo-Frame" => "frame" }, params: params
+
+    assert_response :success
+
+    comment = Comment.last
+
+    assert_equal comment.owner, user2
+  end
+
+  test "create returns a not found response when the current user has no access to a given entry" do
+    user = create(:user)
+    entry = create(:entry, :post)
+    params = {
+      comment: attributes_for(:comment)
+    }
+
+    sign_in user
+
+    post entry_comments_url(entry, format: :turbo_stream), headers: { "Turbo-Frame" => "frame" }, params: params
+
+    assert_response :not_found
+  end
+end

--- a/test/factories/entries.rb
+++ b/test/factories/entries.rb
@@ -3,6 +3,11 @@ FactoryBot.define do
     trait :post do
       entryable { create(:post) }
     end
+
+    trait :comment do
+      entryable { create(:comment) }
+    end
+
     association :owner, factory: :user
   end
 end


### PR DESCRIPTION
Implementa a funcionalidade de comentar em posts. Usuários podem comentar nos seguintes casos:
- O perfil do dono da entry é público
- A entry pertence ao usuário logado
- O usuário logado segue o dono da entry

**Imagem da tela de comentários:**
![image](https://github.com/user-attachments/assets/8d9feec0-a82c-435a-9978-c7007a51c1b9)
