### PR TITLE
refactor: Replace `create` with `new` in tests

### DIFF
--- a/test/models/entry_test.rb
+++ b/test/models/entry_test.rb
@@ -19,7 +19,7 @@ class EntryTest < ActiveSupport::TestCase
 
     post1 = create(:entry, :post, owner: user1)
     post2 = create(:entry, :post, owner: user2)
-    post3 = create(:entry, :post, owner: user3)
+    _post3 = create(:entry, :post, owner: user3)
 
     # user 1 follows user 2
     create(:follow, follower: user1, followee: user2)

--- a/test/models/goal/progress_change_test.rb
+++ b/test/models/goal/progress_change_test.rb
@@ -8,7 +8,7 @@ class Goal::ProgressChangeTest < ActiveSupport::TestCase
   should validate_presence_of(:target)
 
   test "validates the old value must be different than the new value" do
-    goal = create(:goal)
+    goal = Goal.new
     progress_change = goal.progress_changes.build(old_value: 1, new_value: 1, target: 5)
 
     assert_not progress_change.valid?

--- a/test/models/goal_test.rb
+++ b/test/models/goal_test.rb
@@ -41,7 +41,7 @@ class GoalTest < ActiveSupport::TestCase
   end
 
   test "progress returns the progress of the goal" do
-    goal = create(:goal, current: 50, target: 100)
+    goal = Goal.new(current: 50, target: 100)
 
     result = goal.progress
 
@@ -49,7 +49,7 @@ class GoalTest < ActiveSupport::TestCase
   end
 
   test "translated_status returns the translated status name" do
-    goal = build(:goal, status: :completed)
+    goal = Goal.new(status: :completed)
 
     assert_equal I18n.t("activerecord.attributes.goal.status.completed"), goal.translated_status
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -113,20 +113,20 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "allowed to view profile if user is themselves" do
-    user = create(:user, profile_visibility: :private)
+    user = User.new(profile_visibility: :private)
 
     assert user.allowed_to_view_profile?(user)
   end
 
   test "allowed to view profile if the profile is public" do
-    user = create(:user, profile_visibility: :public)
-    user2 = create(:user)
+    user = User.new(profile_visibility: :public)
+    user2 = User.new
 
     assert user.allowed_to_view_profile?(user2)
   end
 
   test "allowed to view profile if the profile is public and user is nil" do
-    user = create(:user, profile_visibility: :public)
+    user = User.new(profile_visibility: :public)
 
     assert user.allowed_to_view_profile?(nil)
   end
@@ -140,7 +140,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "pending_follow_request_for? returns false if user is nil" do
-    user = create(:user)
+    user = User.new
 
     assert_not user.pending_follow_request_for?(nil)
   end


### PR DESCRIPTION
Para melhorar a performance dos testes, troquei o `create` por `new` em alguns casos.