### PR TITLE
fix: Changes feed scope filter order

### DIFF
--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -15,7 +15,7 @@ class Entry < ApplicationRecord
   end
 
   scope :feed, ->(owner: Current.user) do
-    where(entryable_type: FEED_ENTRIES).visible(owner)
+    visible(owner).where(entryable_type: FEED_ENTRIES)
   end
 
   def self.build_with_post(post, owner: Current.user)

--- a/test/models/entry_test.rb
+++ b/test/models/entry_test.rb
@@ -47,6 +47,17 @@ class EntryTest < ActiveSupport::TestCase
     assert_equal [ post ], Entry.feed(owner: user)
   end
 
+  test "feed scope returns followee entries with type Post" do
+    current_user = create(:user)
+    followee = create(:user)
+    create(:follow, follower: current_user, followee:)
+    post = create(:entry, :post, owner: followee)
+
+    create(:entry, entryable_type: User, entryable_id: 1, owner: followee)
+
+    assert_equal [ post ], Entry.feed(owner: current_user)
+  end
+
   test "liked? returns true if entry is already liked by given user" do
     user = create(:user)
     entry = create(:entry, :post, owner: user)


### PR DESCRIPTION
O scope `feed` não está filtrando corretamente pelo `entryable_type`, por causa disso, comentários são carregados no feed como se fossem posts e dão erro:

![image](https://github.com/user-attachments/assets/6a8d9047-d516-407e-b1d9-67a8a5dfce55)
