### PR TITLE
fix: Add loading lazy attribute to avoid visual bugs

### DIFF
--- a/app/views/entries/entryables/_post.html.erb
+++ b/app/views/entries/entryables/_post.html.erb
@@ -76,7 +76,7 @@
           <% end %>
           <% modal.with_close_button %>
           <%= render UI::Modal::BodyComponent.new do %>
-            <%= turbo_frame_tag dom_id(entry, :likes), src: entry_likes_path(entry) do %>
+            <%= turbo_frame_tag dom_id(entry, :likes), src: entry_likes_path(entry), loading: :lazy do %>
               <%= t(".loading") %>
             <% end %>
           <% end %>
@@ -93,10 +93,10 @@
         <% end %>
 
         <%= render UI::Button::Component.new(
-          builder: :a, 
-          href: new_entry_comment_path(entry), 
-          variant: :rounded, 
-          color: :transparent, 
+          builder: :a,
+          href: new_entry_comment_path(entry),
+          variant: :rounded,
+          color: :transparent,
           size: :sm,
           data: {
             turbo: true,


### PR DESCRIPTION
Percebi que tá rolando uns bugs visuais na hora de "Dar kudos" e visualizar eles, por exemplo, quando eu curto um post e abro para visualizar, aparece nenhuma curtida ou apenas a curtida que já existia.


https://github.com/user-attachments/assets/ceabf1b8-b867-4e5a-bbd2-67160d7cbb58

