### PR TITLE
fix: Fix comment creation

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,7 +1,7 @@
 class Comment < ApplicationRecord
   include Entryable
 
-  belongs_to :entry, touch: true
+  belongs_to :parent, class_name: "Entry", foreign_key: :entry_id, inverse_of: :comments, touch: true
   has_one :owner, through: :entry
 
   validates :body, presence: true, length: { maximum: 2200 }

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -4,7 +4,7 @@ class Entry < ApplicationRecord
   delegated_type :entryable, types: %w[ Post Comment ], dependent: :destroy
 
   has_many :likes, dependent: :destroy
-  has_many :comments, dependent: :destroy
+  has_many :comments, dependent: :destroy, inverse_of: :parent
 
   belongs_to :owner, class_name: "User", foreign_key: :owner_id
 

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class CommentTest < ActiveSupport::TestCase
-  should belong_to(:entry)
+  should belong_to(:parent)
   should have_one(:owner).through(:entry)
 
   should validate_presence_of(:body)


### PR DESCRIPTION
Corrige a criação de comentários. Ao tentar criar comentários em produção, aparece um `content missing`. Os logs mostram que está dando um erro no banco de unique constraint. O problema parece ser que no Comment existe um `has_one :entry` (através do concern Entryable) e `belongs_to :entry`:

![image](https://github.com/user-attachments/assets/60a17943-1972-4cf7-afeb-68ea0118ce51)

A solução é mudar o `belongs_to :entry` para `belongs_to :parent`.
