### PR TITLE
config: Setup robots.txt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,9 +22,6 @@ gem "jbuilder"
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 gem "bcrypt", "~> 3.1.7"
 
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: %i[ windows jruby ]
-
 # Use the database-backed adapters for Rails.cache, Active Job, and Action Cable
 gem "solid_cache"
 gem "solid_queue"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -489,7 +489,6 @@ DEPENDENCIES
   tailwind_merge (= 0.16.0)
   thruster
   turbo-rails
-  tzinfo-data
   view_component (= 3.21.0)
   view_component-contrib (= 0.2.4)
   web-console

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -19,7 +19,7 @@ servers:
 # Note: If using Cloudflare, set encryption mode in SSL/TLS setting to "Full" to enable CF-to-app encryption.
 proxy:
   ssl: true
-  host: "<%= ENV.fetch("HOSTNAME") %>"
+  host: <%= ENV.fetch("HOSTNAME") %>
 
 # Credentials for your image host.
 registry:
@@ -40,10 +40,10 @@ env:
     SOLID_QUEUE_IN_PUMA: true
 
     # Set number of processes dedicated to Solid Queue (default: 1)
-    # JOB_CONCURRENCY: 3
+    JOB_CONCURRENCY: 1
 
     # Set number of cores available to the application on each server (default: 1).
-    # WEB_CONCURRENCY: 2
+    WEB_CONCURRENCY: 1
 
     # Match this to any external database server to configure Active Record correctly
     # Use goals-db for a db accessory server on same machine via local kamal docker network.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,4 @@
-# See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+User-agent: *
+Disallow: /
+Allow: /sessions/new
+Allow: /registrations/new


### PR DESCRIPTION
Configura o arquivo `robots.txt` para definir que buscadores indexem apenas as páginas de login e cadastro.