### PR TITLE
fix: Add fallback for entryables without show page

### DIFF
--- a/app/controllers/entries/likes_controller.rb
+++ b/app/controllers/entries/likes_controller.rb
@@ -18,7 +18,8 @@ module Entries
           format.html { redirect_to @entry.entryable }
           format.turbo_stream
         else
-          redirect_to @entry.entryable, alert: t(".error")
+          format.html { redirect_to @entry.entryable, alert: t(".error") }
+          format.turbo_stream
         end
       end
     end

--- a/config/locales/pt-BR/views/entries.yml
+++ b/config/locales/pt-BR/views/entries.yml
@@ -17,6 +17,8 @@ pt-BR:
       likes_count:
         likes: "%{count} kudos"
         loading: "Carregando..."
+      create:
+        error: "Não foi possível dar kudos"
     comments:
       comment_section:
         load_more_comments: Carregar mais comentários

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,4 +53,8 @@ Rails.application.routes.draw do
       resource :follow_request, only: %i[create destroy]
     end
   end
+
+  # Entryables without show page will redirected to the home page
+  get "posts/:id" => "homes#show", as: :post
+  get "comments/:id" => "homes#show", as: :comment
 end


### PR DESCRIPTION
No controller de likes existem redirects para a página show das entryables, mas não há entryables com uma página show. Esse PR adiciona um fallback que aponta a página de show das entryables para a home.