### PR TITLE
fix: Update the entryable

### DIFF
--- a/app/models/entry/like.rb
+++ b/app/models/entry/like.rb
@@ -3,4 +3,12 @@ class Entry::Like < ApplicationRecord
   belongs_to :user
 
   validates :user, uniqueness: { scope: :entry }
+
+  after_save :touch_entryable
+  after_destroy :touch_entryable
+
+  private
+  def touch_entryable
+    entry.entryable.touch
+  end
 end

--- a/app/views/feed/index.html.erb
+++ b/app/views/feed/index.html.erb
@@ -20,7 +20,7 @@
     <div class="mb-4">
       <%= turbo_frame_tag :feed, class: "space-y-4" do %>
         <% if @entries.any? %>
-          <%= render partial: "entry", collection: @entries %>
+          <%= render partial: "entry", collection: @entries, cached: ->(entry) { [Current.user, entry] } %>
         <% else %>
           <%= render "no_entries" %>
         <% end %>

--- a/test/models/entry/like_test.rb
+++ b/test/models/entry/like_test.rb
@@ -15,4 +15,26 @@ class Entry::LikeTest < ActiveSupport::TestCase
     assert_not like.valid?
     assert_includes like.errors[:user], I18n.t("errors.messages.taken")
   end
+
+  test "after save touches the entryable" do
+    entry = create(:entry, :post)
+    user = create(:user)
+
+    like = create(:entry_like, entry:, user:)
+
+    assert_changes -> { entry.entryable.updated_at } do
+      like.save!
+    end
+  end
+
+  test "after destroy touches the entryable" do
+    entry = create(:entry, :post)
+    user = create(:user)
+
+    like = create(:entry_like, entry:, user:)
+
+    assert_changes -> { entry.entryable.updated_at } do
+      like.destroy
+    end
+  end
 end


### PR DESCRIPTION
Adiciona callbacks no Entry::Like para atualizar o `updated_at` dos posts e comentários associados. Essa mudança vai garantir que a cache é invalidada quando um like é criado ou destruído.