### PR TITLE
feat: Add visibility control to goals

### DIFF
--- a/app/controllers/goals_controller.rb
+++ b/app/controllers/goals_controller.rb
@@ -42,6 +42,6 @@ class GoalsController < DashboardController
   end
 
   def goal_params
-    params.require(:goal).permit(:title, :description, :start_date, :end_date, :current, :target)
+    params.require(:goal).permit(:title, :description, :start_date, :end_date, :current, :target, :visibility)
   end
 end

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -1,5 +1,6 @@
 class Goal < ApplicationRecord
-  enum :status, [ :pending, :completed ], with_model_name: true
+  enum :status, [ :pending, :completed ]
+  enum :visibility, [ :public, :private ], suffix: :goal, default: :public
 
   has_many :progress_changes, dependent: :destroy
 

--- a/app/views/goals/_form.html.erb
+++ b/app/views/goals/_form.html.erb
@@ -11,6 +11,19 @@
     <%= form.error_message :description %>
   <% end %>
 
+  <%= form.form_group :visibility do %>
+    <%= form.label :visibility, nil, class: "form-label-required" %>
+    <%= form.select(
+      :visibility,
+      [
+        [t("activerecord.attributes.goal.visibility.public"), :public],
+        [t("activerecord.attributes.goal.visibility.private"), :private],
+      ],
+      required: true,
+    ) %>
+    <%= form.error_message :visibility %>
+  <% end %>
+
   <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
     <%= form.form_group :start_date do %>
       <%= form.label :start_date, nil, class: "form-label-required" %>

--- a/app/views/goals/_goal.html.erb
+++ b/app/views/goals/_goal.html.erb
@@ -13,15 +13,38 @@
   <div class="flex-1 flex flex-col justify-end">
     <div class="px-3 pt-3">
       <div class="flex justify-between items-center">
-        <div class="flex items-center gap-2">
-          <%= render UI::Icon::Component.new(
-            "clock",
-            variant: :outline,
-            class: "text-zinc-600 dark:text-zinc-400",
-          ) %>
-          <span class="text-sm text-zinc-600 dark:text-zinc-400">
-            <%= localize(goal.start_date.to_date, format: :short_month) %>
-          </span>
+        <div class="flex items-center gap-4">
+          <%= render UI::Tooltip::Component.new do |tooltip| %>
+            <% tooltip.with_trigger(class: "flex items-center gap-2") do %>
+              <%= render UI::Icon::Component.new(
+                "clock",
+                variant: :outline,
+                class: "text-zinc-600 dark:text-zinc-400",
+              ) %>
+
+              <span class="text-sm text-zinc-600 dark:text-zinc-400">
+                <%= localize(goal.start_date.to_date, format: :short_month) %>
+              </span>
+            <% end %>
+
+            <% tooltip.with_body.with_content(localize(goal.start_date.to_date, format: :long)) %>
+          <% end %>
+
+          <% if goal.private_goal? %>
+            <div class="flex items-center gap-2">
+              <%= render UI::Tooltip::Component.new do |tooltip| %>
+                <% tooltip.with_trigger do %>
+                  <%= render UI::Icon::Component.new(
+                    "eye-slash",
+                    variant: :outline,
+                    class: "text-zinc-600 dark:text-zinc-400",
+                  ) %>
+                <% end %>
+
+                <% tooltip.with_body.with_content(t(".private_goal")) %>
+              <% end %>
+            </div>
+          <% end %>
         </div>
 
         <%= render UI::Dropdown::Component.new(alignment: :right) do |dropdown| %>

--- a/config/locales/pt-BR/models/goals.yml
+++ b/config/locales/pt-BR/models/goals.yml
@@ -13,6 +13,10 @@ pt-BR:
         status: Status
         status:
           completed: Finalizado
+        visibility:
+          one: Visiblidade
+          public: Pública
+          private: Privada
     errors:
       models:
         goal:

--- a/config/locales/pt-BR/views/goals.yml
+++ b/config/locales/pt-BR/views/goals.yml
@@ -29,7 +29,8 @@ pt-BR:
       edit_goal: Editar meta
       update_progress: Atualizar progresso
       destroy_goal: Excluir meta
-
+      public_goal: Qualquer usuário pode ver esta meta
+      private_goal: Apenas você pode ver esta meta
     update_progresses:
       edit:
         cancel: Cancelar
@@ -43,7 +44,6 @@ pt-BR:
     no_goals:
       title: Sem metas ainda? Comece agora!
       description: Todo grande objetivo começa com um primeiro passo. Crie sua primeira meta e dê o primeiro passo rumo ao seu sucesso!
-
     progress_changes:
       posts:
         new:

--- a/db/migrate/20250222193345_add_visibility_to_goals.rb
+++ b/db/migrate/20250222193345_add_visibility_to_goals.rb
@@ -1,0 +1,5 @@
+class AddVisibilityToGoals < ActiveRecord::Migration[8.1]
+  def change
+    add_column :goals, :visibility, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_02_08_171856) do
+ActiveRecord::Schema[8.1].define(version: 2025_02_22_193345) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -108,6 +108,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_02_08_171856) do
     t.string "title", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
+    t.integer "visibility", default: 0
     t.index ["user_id"], name: "index_goals_on_user_id"
   end
 

--- a/test/models/goal_test.rb
+++ b/test/models/goal_test.rb
@@ -9,6 +9,9 @@ class GoalTest < ActiveSupport::TestCase
   should validate_length_of(:description).is_at_most(100)
   should validate_numericality_of(:current)
 
+  should define_enum_for(:status)
+  should define_enum_for(:visibility)
+
   test "start_date presence" do
     goal = Goal.new(start_date: Time.zone.today)
 


### PR DESCRIPTION
- Adiciona a coluna `visibility` na tabela `goals`
- Adiciona um ícone no card da meta para indicar que a meta é privada

![image](https://github.com/user-attachments/assets/74f37cdd-8c11-4994-94d1-7760a43ba85d)
