### PR TITLE
feat: Add a destroy post button for the profile feed posts

### DIFF
--- a/app/controllers/profiles/feed_entries_controller.rb
+++ b/app/controllers/profiles/feed_entries_controller.rb
@@ -1,0 +1,22 @@
+module Profiles
+  class FeedEntriesController < ProfilesController
+    include UserScoped
+
+    before_action :set_entry, only: %i[destroy]
+
+    def destroy
+      authorize!(@entry, with: Profiles::FeedEntryPolicy)
+      @entry.destroy
+
+      respond_to do |format|
+        format.html { redirect_to profile_path(@user.username), notice: t(".success") }
+        format.turbo_stream { flash.now[:notice] = t(".success") }
+      end
+    end
+
+    private
+    def set_entry
+      @entry = Entry.find(params[:id])
+    end
+  end
+end

--- a/app/models/concerns/entryable.rb
+++ b/app/models/concerns/entryable.rb
@@ -2,6 +2,6 @@ module Entryable
   extend ActiveSupport::Concern
 
   included do
-    has_one :entry, as: :entryable, touch: true
+    has_one :entry, as: :entryable, touch: true, dependent: :destroy
   end
 end

--- a/app/policies/entry_policy.rb
+++ b/app/policies/entry_policy.rb
@@ -1,0 +1,10 @@
+class EntryPolicy < ApplicationPolicy
+  def destroy?
+    owner?
+  end
+
+  private
+  def owner?
+    record.owner_id == user&.id
+  end
+end

--- a/app/policies/profiles/feed_entry_policy.rb
+++ b/app/policies/profiles/feed_entry_policy.rb
@@ -1,0 +1,12 @@
+module Profiles
+  class FeedEntryPolicy < ProfilesPolicy
+    def destroy?
+      owner?
+    end
+
+    private
+    def owner?
+      record.owner_id == user&.id
+    end
+  end
+end

--- a/app/views/entries/entryables/_post.html.erb
+++ b/app/views/entries/entryables/_post.html.erb
@@ -1,7 +1,7 @@
 <% post = entry.entryable %>
 
 <%= render UI::Card::Component.new(class: "w-full") do |header| %>
-  <%= render UI::Card::HeaderComponent.new do |header| %>
+  <%= render UI::Card::HeaderComponent.new(class: "flex justify-between") do |header| %>
     <div class="flex items-center gap-2 mb-2">
       <%= link_to profile_path(entry.owner.username), class: "inline-flex", data: { turbo_frame: :_top } do %>
         <%= render UI::Avatar::Component.new(
@@ -16,7 +16,31 @@
         <p class="font-heading text-sm text-zinc-500 font-normal dark:text-zinc-400"><%= localize(post.created_at.to_time, format: :friendly) %></p>
       </div>
     </div>
+
+    <% if allowed_to?(:destroy?, entry) %>
+      <div>
+        <%= render UI::Dropdown::Component.new(alignment: :right) do |dropdown| %>
+          <% dropdown.with_trigger do %>
+            <%= render UI::Button::Component.new(variant: :square) do |button| %>
+              <% button.with_leading_icon("ellipsis-horizontal") %>
+            <% end %>
+          <% end %>
+
+          <% dropdown.with_item do %>
+            <%= button_to(
+              t(".destroy"),
+              destroy_entry_path,
+              method: :delete,
+              data: {
+                turbo_frame: :_top,
+              },
+            ) %>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
   <% end %>
+
   <%= render UI::Card::BodyComponent.new do |header| %>
     <div class="flex flex-col">
       <p class="h6">

--- a/app/views/feed/_entry.html.erb
+++ b/app/views/feed/_entry.html.erb
@@ -1,3 +1,9 @@
-<% cache([:feed, entry, Current.user]) do %>
-  <%= render "entries/entryables/#{entry.entryable_name}", entry: %>
+<%= turbo_frame_tag entry, class: "block" do %>
+  <%= render(
+    partial: "entries/entryables/#{entry.entryable_name}",
+    locals: {
+      entry:,
+      destroy_entry_path: ""
+    },
+  ) %>
 <% end %>

--- a/app/views/feed/index.html.erb
+++ b/app/views/feed/index.html.erb
@@ -20,7 +20,9 @@
     <div class="mb-4">
       <%= turbo_frame_tag :feed, class: "space-y-4" do %>
         <% if @entries.any? %>
-          <%= render partial: "entry", collection: @entries, cached: ->(entry) { [Current.user, entry] } %>
+          <%= render partial: "entry",
+          collection: @entries,
+          cached: ->(entry) { [:feed, Current.user, entry] } %>
         <% else %>
           <%= render "no_entries" %>
         <% end %>

--- a/app/views/goals/_goal.html.erb
+++ b/app/views/goals/_goal.html.erb
@@ -2,7 +2,7 @@
   <%= render UI::Card::HeaderComponent.new do |header| %>
     <% header.with_title(class: "flex justify-between") do %>
       <%= goal.title %>
-      <span class="text-sm"><%= strip_zeros(goal.current) %>
+      <span class="text-sm whitespace-nowrap"><%= strip_zeros(goal.current) %>
         /
         <%= strip_zeros(goal.target) %></span>
     <% end %>

--- a/app/views/posts/destroy.turbo_stream.erb
+++ b/app/views/posts/destroy.turbo_stream.erb
@@ -1,0 +1,19 @@
+<%= turbo_stream.remove(@post.entry) %>
+
+<%= turbo_stream.replace :flash do %>
+  <%= render partial: "shared/flash" %>
+<% end %>
+
+<% if Current.user.entries.feed.none? %>
+  <%= turbo_stream.append :feed do %>
+    <div class="mb-4">
+      <%= render "feed/no_entries" %>
+    </div>
+  <% end %>
+
+  <%= turbo_stream.append :profile_feed do %>
+    <div class="mb-4">
+      <%= render "feed/no_entries" %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/profiles/_entry.html.erb
+++ b/app/views/profiles/_entry.html.erb
@@ -1,1 +1,9 @@
-<%= render "entries/entryables/#{entry.entryable_name}", entry: %>
+<%= turbo_frame_tag entry, class: "block" do %>
+  <%= render(
+    partial: "entries/entryables/#{entry.entryable_name}",
+    locals: {
+      entry:,
+      destroy_entry_path: profile_feed_entry_path(@user.username, entry),
+    },
+  ) %>
+<% end %>

--- a/app/views/profiles/feed_entries/destroy.turbo_stream.erb
+++ b/app/views/profiles/feed_entries/destroy.turbo_stream.erb
@@ -1,0 +1,11 @@
+<%= turbo_stream.remove @entry %>
+
+<%= turbo_stream.replace :flash do %>
+  <%= render "shared/flash" %>
+<% end %>
+
+<% if Entry.posts_owned_by(@user).none? %>
+  <%= turbo_stream.append :profile_feed do %>
+    <%= render partial: "profiles/no_entries" %>
+  <% end %>
+<% end %>

--- a/app/views/profiles/show.turbo_stream.erb
+++ b/app/views/profiles/show.turbo_stream.erb
@@ -1,3 +1,7 @@
+<% @entries.each do |entry| %>
+  <%= turbo_stream.remove entry %>
+<% end %>
+
 <%= turbo_stream.append :profile_feed do %>
   <%= render partial: "entry", collection: @entries, cached: ->(entry) { [:profile_feed, entry, Current.user] } %>
 <% end %>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,1 +1,4 @@
+require "pagy/extras/overflow"
+
 Pagy::DEFAULT[:limit] = 10
+Pagy::DEFAULT[:overflow] = :empty_page

--- a/config/locales/pt-BR/views/entries.yml
+++ b/config/locales/pt-BR/views/entries.yml
@@ -4,6 +4,7 @@ pt-BR:
       post:
         likes: "%{count} kudos"
         loading: "Carregando..."
+        destroy: "Excluir"
       comment:
         likes: "%{count} kudos"
         loading: "Carregando..."

--- a/config/locales/pt-BR/views/posts.yml
+++ b/config/locales/pt-BR/views/posts.yml
@@ -7,6 +7,8 @@ pt-BR:
       submit: Criar publicação
     create:
       success: Publicação criada com sucesso
+    destroy:
+      success: Publicação excluída com sucesso
     form:
       go_back: Voltar
       allowed_file_types: PNG, JPG, GIF ou WEBP

--- a/config/locales/pt-BR/views/profiles.yml
+++ b/config/locales/pt-BR/views/profiles.yml
@@ -37,3 +37,6 @@ pt-BR:
         description: Parece que este usuário ainda não definiu suas metas. Fique de olho, novidades podem aparecer em breve!
       next_page:
         loading: Carregando...
+    feed_entries:
+      destroy:
+        success: Publicação removida

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,10 +52,10 @@ Rails.application.routes.draw do
       resources :followers, only: %i[index destroy]
       resource :follow_request, only: %i[create destroy]
       resources :goals, only: %i[index]
+      resources :feed_entries, only: %i[destroy]
     end
   end
 
   # Entryables without show page will redirected to the home page
-  get "posts/:id" => "homes#show", as: :post
   get "comments/:id" => "homes#show", as: :comment
 end

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -9,4 +9,12 @@ class PostTest < ActiveSupport::TestCase
   should validate_content_type_of(:images).allowing("image/png", "image/gif", "image/jpeg", "image/gif")
   should validate_size_of(:images).less_than_or_equal_to(8.megabytes)
   should validate_limits_of(:images).max(5)
+
+  test "destroys entry when post is destroyed" do
+    entry = create(:entry, :post)
+
+    assert_difference "Entry.count", -1 do
+      entry.post.destroy
+    end
+  end
 end

--- a/test/policies/entry_policy_test.rb
+++ b/test/policies/entry_policy_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class EntryPolicyTest < ActiveSupport::TestCase
+  test "destroy? returns true if user owns the entry" do
+    user = build_stubbed(:user)
+    entry = build_stubbed(:entry, :post, owner: user)
+
+    policy = EntryPolicy.new(entry, user:)
+
+    assert policy.destroy?
+  end
+
+  test "destroy? returns false if user does not own the entry" do
+    user = build_stubbed(:user)
+    user2 = build_stubbed(:user)
+    entry = build_stubbed(:entry, :post, owner: user2)
+
+    policy = EntryPolicy.new(entry, user:)
+
+    assert_not policy.destroy?
+  end
+end

--- a/test/policies/profiles/feed_entry_policy_test.rb
+++ b/test/policies/profiles/feed_entry_policy_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+module Profiles
+  class FeedEntryTest < ActiveSupport::TestCase
+    test "destroy? returns true if the profile owner owns the entry and the current user is the profile owner" do
+      user = build_stubbed(:user)
+      entry = build_stubbed(:entry, :post, owner: user)
+
+      policy = Profiles::FeedEntryPolicy.new(entry, user:, profile_owner: user)
+
+      assert policy.destroy?
+    end
+
+    test "destroy? returns false if the profile owner does not own the entry" do
+      user = build_stubbed(:user)
+      entry = build_stubbed(:entry, :post)
+
+      policy = Profiles::FeedEntryPolicy.new(entry, user:, profile_owner: user)
+
+      assert_not policy.destroy?
+    end
+
+    test "destroy? returns false if the current user is not the profile owner" do
+      profile_owner = build_stubbed(:user)
+      user = build_stubbed(:user)
+      entry = build_stubbed(:entry, :post, owner: profile_owner)
+
+      policy = Profiles::FeedEntryPolicy.new(entry, user:, profile_owner: profile_owner)
+
+      assert_not policy.destroy?
+    end
+
+    test "destroy? returns false if the current user is nil" do
+      profile_owner = build_stubbed(:user)
+      entry = build_stubbed(:entry, :post, owner: profile_owner)
+
+      policy = Profiles::FeedEntryPolicy.new(entry, user: nil, profile_owner: profile_owner)
+
+      assert_not policy.destroy?
+    end
+  end
+end


### PR DESCRIPTION
Implementa a remoção de posts a partir do perfil do usuário. Adicionei a action destroy em um novo controller `Profiles::FeedEntriesController` ao invés de adicionar em `PostsController`, porque depois de remover o post, se não houver mais posts, eu preciso adicionar o empty state no feed. Como o empy state do perfil é diferente do empty state do feed, então preferi separar esses controllers ao invés de ter que tratar esses casos no turbo_stream.

![image](https://github.com/user-attachments/assets/e0745da8-d2ac-4399-8534-f1adc802f0e2)
![image](https://github.com/user-attachments/assets/bdc2c9c5-34b7-416a-86c3-11d6612053b1)