### PR TITLE
feat: Add counter cache for likes

### DIFF
--- a/app/components/features/entries/like_count/component.html.erb
+++ b/app/components/features/entries/like_count/component.html.erb
@@ -1,6 +1,6 @@
 <%= render UI::Modal::Component.new(class: "w-full max-w-lg") do |modal| %>
   <% modal.with_trigger do %>
-    <%= tag.p t(".likes", count: entry.likes.count), class: "text-sm text-zinc-500 font-normal dark:text-zinc-400 cursor-pointer" %>
+    <%= tag.p t(".likes", count: entry.likes_count), class: "text-sm text-zinc-500 font-normal dark:text-zinc-400 cursor-pointer" %>
   <% end %>
   <% modal.with_close_button %>
   <%= render UI::Modal::BodyComponent.new do %>

--- a/app/models/entry/like.rb
+++ b/app/models/entry/like.rb
@@ -1,5 +1,5 @@
 class Entry::Like < ApplicationRecord
-  belongs_to :entry, touch: true
+  belongs_to :entry, touch: true, counter_cache: true
   belongs_to :user
 
   validates :user, uniqueness: { scope: :entry }
@@ -9,6 +9,6 @@ class Entry::Like < ApplicationRecord
 
   private
   def touch_entryable
-    entry.entryable.touch
+    entry.entryable&.touch
   end
 end

--- a/app/views/entries/likes/index.html.erb
+++ b/app/views/entries/likes/index.html.erb
@@ -2,7 +2,7 @@
   <div class="flex flex-col pb-4">
     <h3 class="text-xl font-semibold font-heading text-zinc-900
         dark:text-zinc-100 tracking-tight not-prose mb-4">
-      <%= t(".likes", count: @entry.likes.count)%>
+      <%= t(".likes", count: @entry.likes_count)%>
     </h3>
     <% if @likes.present? %>
       <div class="lg:max-h-[320px] lg:overflow-y-auto">
@@ -14,7 +14,7 @@
           ) %>
         <% end %>
 
-        <% if @entry.likes.count > 5 %>
+        <% if @entry.likes_count > 5 %>
           <%= turbo_frame_tag dom_id(@entry, :next_page) do %>
             <div class="mt-1">
               <%= render(LoadMoreButton::Component.new(

--- a/db/migrate/20250223001713_add_likes_count_to_entries.rb
+++ b/db/migrate/20250223001713_add_likes_count_to_entries.rb
@@ -1,0 +1,5 @@
+class AddLikesCountToEntries < ActiveRecord::Migration[8.1]
+  def change
+    add_column :entries, :likes_count, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20250223002249_populate_entry_likes_count.rb
+++ b/db/migrate/20250223002249_populate_entry_likes_count.rb
@@ -1,0 +1,7 @@
+class PopulateEntryLikesCount < ActiveRecord::Migration[8.1]
+  def up
+    Entry.find_each do |entry|
+      Entry.reset_counters(entry.id, :likes)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_02_22_193345) do
+ActiveRecord::Schema[8.1].define(version: 2025_02_23_002249) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -51,6 +51,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_02_22_193345) do
     t.datetime "created_at", null: false
     t.integer "entryable_id", null: false
     t.string "entryable_type", null: false
+    t.integer "likes_count", default: 0, null: false
     t.integer "owner_id", null: false
     t.datetime "updated_at", null: false
     t.index ["entryable_id", "entryable_type"], name: "index_entries_on_entryable_id_and_entryable_type", unique: true


### PR DESCRIPTION
Adiciona `counter_cache` para substituir queries do tipo `entry.likes.count` por `entry.likes_count`.

**Antes:**
![image](https://github.com/user-attachments/assets/87e6930a-ea95-4c87-9ef9-5a559f40c123)

**Depois:**
![image](https://github.com/user-attachments/assets/6bb7140e-8e8b-45af-a845-d2d9b38fcf25)

