### PR TITLE
feat: Add user goals to profile

### DIFF
--- a/app/controllers/profiles/goals_controller.rb
+++ b/app/controllers/profiles/goals_controller.rb
@@ -1,0 +1,10 @@
+module Profiles
+  class GoalsController < ProfilesController
+    include UserScoped
+
+    def index
+      scope = authorized_scope(Goal.all.order(created_at: :desc), with: Profiles::GoalPolicy)
+      @pagy, @goals = pagy(scope)
+    end
+  end
+end

--- a/app/models/goal/progress_change.rb
+++ b/app/models/goal/progress_change.rb
@@ -1,6 +1,8 @@
 class Goal::ProgressChange < ApplicationRecord
   belongs_to :goal
 
+  has_many :posts, dependent: :destroy, foreign_key: "goal_progress_change_id"
+
   validates :old_value, presence: true, numericality: true
   validates :new_value, presence: true, numericality: true
   validates :target, presence: true, numericality: true

--- a/app/views/goals/update_progresses/edit.html.erb
+++ b/app/views/goals/update_progresses/edit.html.erb
@@ -1,7 +1,10 @@
 <%= turbo_frame_tag :modal do %>
   <%= render UI::Modal::Component.new(
     open: true,
-    class: "w-full max-w-sm"
+    class: "w-full max-w-sm",
+    data: {
+      turbo_temporary: true
+    }
   ) do |modal| %>
     <% modal.with_close_button %>
 
@@ -33,15 +36,17 @@
             required: true,
             class: "text-center",
             data: {
-              action: "input->sum-updater#update"
+              action: "input->sum-updater#update",
             },
-            onenter: "this.form.requestSubmit()"
+            onenter: "this.form.requestSubmit()",
           ) %>
         <% end %>
 
         <div>
           <div class="form-input text-center" disabled>
-            <span data-sum-updater-target="output"><%= strip_zeros(@goal.current) %></span> / <span><%= strip_zeros(@goal.target) %></span>
+            <span data-sum-updater-target="output"><%= strip_zeros(@goal.current) %></span>
+            /
+            <span><%= strip_zeros(@goal.target) %></span>
           </div>
         </div>
       <% end %>
@@ -52,14 +57,13 @@
           color: :transparent,
           class: "w-full",
           data: {
-            action: "click->modal#close"
-          }
+            action: "click->modal#close",
+          },
         ).with_content(t(".cancel")) %>
 
-        <%= render UI::Button::Component.new(
-          class: "w-full",
-          type: :submit
-        ).with_content(t(".submit")) %>
+        <%= render UI::Button::Component.new(class: "w-full", type: :submit).with_content(
+          t(".submit"),
+        ) %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/layouts/profiles/_content.html.erb
+++ b/app/views/layouts/profiles/_content.html.erb
@@ -15,7 +15,10 @@
         <% tab.with_title.with_content(t(".nav.followers")) %>
       <% end %>
 
-      <% tab_nav.with_tab do |tab| %>
+      <% tab_nav.with_tab(
+        href: profile_goals_path(@user.username),
+        active: current_page?(profile_goals_path(@user.username)),
+      ) do |tab| %>
         <% tab.with_title.with_content(t(".nav.goals")) %>
       <% end %>
     <% end %>

--- a/app/views/profiles/followers/_follower.html.erb
+++ b/app/views/profiles/followers/_follower.html.erb
@@ -1,4 +1,4 @@
-<li class="flex flex-wrap items-center justify-start space-y-3 md:space-y-0 py-6 md:py-4">
+<li class="flex flex-wrap items-center justify-start space-y-3 md:space-y-0 pb-6 md:pb-4">
   <div class="md:flex-1 w-full">
     <div class="flex md:items-center items-start space-x-3">
       <%= link_to profile_path(follower.username) do %>

--- a/app/views/profiles/followers/_pending_follow_requests.html.erb
+++ b/app/views/profiles/followers/_pending_follow_requests.html.erb
@@ -1,17 +1,19 @@
 <div class="pb-4">
   <div class="flex md:items-center items-start space-x-3">
     <%= link_to follow_requests_path do %>
-      <%= render UI::Icon::Component.new(
-        "users",
-        class: "md:size-10 size-16"
-      ) %>
+      <%= render UI::Icon::Component.new("users", class: "md:size-10 size-16") %>
     <% end %>
 
     <div class="flex items-center justify-between flex-1">
       <div class="flex-1">
         <div class="flex gap-2">
           <%= link_to follow_requests_path do %>
-            <h4 class="font-medium md:text-base text-lg leading-tight text-zinc-700 line-clamp-1 dark:text-zinc-50">
+            <h4
+              class="
+                font-medium md:text-base text-lg leading-tight text-zinc-700 line-clamp-1
+                dark:text-zinc-50
+              "
+            >
               <%= t(".title") %>
             </h4>
           <% end %>
@@ -19,14 +21,21 @@
 
         <div>
           <%= link_to follow_requests_path do %>
-            <h4 class="gont-light md:text-sm text-base text-zinc-500 leading-tight line-clamp-1 dark:text-zinc-300/80">
+            <h4
+              class="
+                gont-light md:text-sm text-base text-zinc-500 leading-tight line-clamp-1
+                dark:text-zinc-300/80
+              "
+            >
               <%= t(".description") %>
             </h4>
           <% end %>
         </div>
       </div>
 
-      <%= render UI::Badge::Component.new(color: :pink).with_content(@user.follow_requests.count) %>
+      <%= render UI::Badge::Component.new(color: :pink).with_content(
+        @user.follow_requests.count,
+      ) %>
     </div>
   </div>
 </div>

--- a/app/views/profiles/goals/_next_page.html.erb
+++ b/app/views/profiles/goals/_next_page.html.erb
@@ -1,0 +1,7 @@
+<%= turbo_frame_tag :next_page, src: profile_goals_path(@user.username, format: :turbo_stream, page: pagy.next), loading: :lazy do %>
+  <div class="flex items-center justify-center">
+    <span class="text-zinc-500 dark:text-zinc-300">
+      <%= t(".loading") %>
+    </span>
+  </div>
+<% end %>

--- a/app/views/profiles/goals/_no_goals.html.erb
+++ b/app/views/profiles/goals/_no_goals.html.erb
@@ -1,0 +1,7 @@
+<div class="max-w-xl mx-auto">
+  <%= render UI::EmptyState::Component.new do |empty_state| %>
+    <% empty_state.with_icon("question-mark-circle", class: "size-8 font-semibold font-heading text-zinc-900 dark:text-zinc-100") %>
+    <% empty_state.with_title.with_content(t(".title")) %>
+    <% empty_state.with_description.with_content(t(".description")) %>
+  <% end %>
+</div>

--- a/app/views/profiles/goals/index.html.erb
+++ b/app/views/profiles/goals/index.html.erb
@@ -1,0 +1,25 @@
+<%= provide(:title, t(".title")) %>
+
+<div>
+  <div class="mb-4">
+    <%= turbo_frame_tag :goals, class: "space-y-4" do %>
+      <% if @goals.any? %>
+        <%= render(
+          partial: "goals/goal",
+          collection: @goals,
+          cached: ->(goal) { [Current.user, goal] },
+        ) %>
+      <% else %>
+        <% if profile_owner? %>
+          <%= render partial: "goals/no_goals" %>
+        <% else %>
+          <%= render partial: "no_goals" %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <% if @pagy.next %>
+    <%= render partial: "next_page", locals: { pagy: @pagy } %>
+  <% end %>
+</div>

--- a/app/views/profiles/goals/index.turbo_stream.erb
+++ b/app/views/profiles/goals/index.turbo_stream.erb
@@ -1,0 +1,13 @@
+<%= turbo_stream.append :goals do %>
+  <%= render(
+    partial: "goals/goal",
+    collection: @goals,
+    cached: ->(goal) { [Current.user, goal] },
+  ) %>
+<% end %>
+
+<%= turbo_stream.replace :next_page do %>
+  <% if @pagy.next %>
+    <%= render partial: "next_page", locals: { pagy: @pagy } %>
+  <% end %>
+<% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -2,9 +2,15 @@
   <div class="mb-4">
     <%= turbo_frame_tag :profile_feed, class: "space-y-4" do %>
       <% if @entries.any? %>
-        <%= render partial: "entry", collection: @entries, cached: ->(entry) { [:profile_feed, entry, Current.user] } %>
+        <%= render partial: "entry",
+        collection: @entries,
+        cached: ->(entry) { [:profile_feed, entry, Current.user] } %>
       <% else %>
-        <%= render partial: "no_entries" %>
+        <% if profile_owner? %>
+          <%= render partial: "feed/no_entries" %>
+        <% else %>
+          <%= render partial: "no_entries" %>
+        <% end %>
       <% end %>
     <% end %>
   </div>

--- a/config/locales/pt-BR/views/profiles.yml
+++ b/config/locales/pt-BR/views/profiles.yml
@@ -29,3 +29,11 @@ pt-BR:
     no_entries:
       title: Nenhuma publicação recente disponível
       description: Este usuário ainda não compartilhou nenhuma publicação. Volte mais tarde para ver as novidades!
+    goals:
+      index:
+        title: Goals | Metas
+      no_goals:
+        title: Nenhuma meta por aqui... ainda!
+        description: Parece que este usuário ainda não definiu suas metas. Fique de olho, novidades podem aparecer em breve!
+      next_page:
+        loading: Carregando...

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Rails.application.routes.draw do
     scope module: :profiles do
       resources :followers, only: %i[index destroy]
       resource :follow_request, only: %i[create destroy]
+      resources :goals, only: %i[index]
     end
   end
 

--- a/test/controllers/profiles/goals_controller_test.rb
+++ b/test/controllers/profiles/goals_controller_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+require "action_policy/test_helper"
+
+class Profiles::GoalsControllerTest < ActionDispatch::IntegrationTest
+  include ActionPolicy::TestHelper
+
+  test "index" do
+    user = create(:user)
+
+    sign_in user
+
+    get profile_goals_url(user.username)
+
+    assert_response :success
+  end
+
+  test "index has authorized scope" do
+    user = create(:user)
+
+    sign_in user
+
+    assert_have_authorized_scope(type: :active_record_relation, with: Profiles::GoalPolicy) do
+      get profile_goals_url(user.username)
+    end
+  end
+end

--- a/test/factories/goals.rb
+++ b/test/factories/goals.rb
@@ -7,5 +7,13 @@ FactoryBot.define do
     start_date { Time.zone.today }
     current { 0 }
     target { 10 }
+
+    trait :public do
+      visibility { :public }
+    end
+
+    trait :private do
+      visibility { :private }
+    end
   end
 end

--- a/test/models/goal/progress_change_test.rb
+++ b/test/models/goal/progress_change_test.rb
@@ -3,6 +3,8 @@ require "test_helper"
 class Goal::ProgressChangeTest < ActiveSupport::TestCase
   should belong_to(:goal)
 
+  should have_many(:posts)
+
   should validate_presence_of(:old_value)
   should validate_presence_of(:new_value)
   should validate_presence_of(:target)

--- a/test/policies/profiles/goal_policy_test.rb
+++ b/test/policies/profiles/goal_policy_test.rb
@@ -1,0 +1,56 @@
+require "test_helper"
+
+module Profiles
+  class GoalPolicyTest < ActiveSupport::TestCase
+    test "the default scope lists public and private goals when the current user is the profile owner" do
+      user = create(:user)
+      public_goal = create(:goal, :public, user:)
+      private_goal = create(:goal, :private, user:)
+
+      policy = Profiles::GoalPolicy.new(user:, profile_owner: user)
+      goals = policy.apply_scope(Goal.all, type: :active_record_relation)
+
+      assert_equal [ public_goal, private_goal ], goals
+    end
+
+    test "the default scope lists goals from the profile owner only" do
+      user = create(:user)
+      public_goal = create(:goal, :public, user:)
+      private_goal = create(:goal, :private, user:)
+
+      create(:goal)
+
+      policy = Profiles::GoalPolicy.new(user:, profile_owner: user)
+      goals = policy.apply_scope(Goal.all, type: :active_record_relation)
+
+      assert_equal [ public_goal, private_goal ], goals
+    end
+
+    test "guest users can only see public goals" do
+      user = create(:user)
+      public_goal = create(:goal, :public, user:)
+      _private_goal = create(:goal, :private, user:)
+
+      create(:goal)
+
+      policy = Profiles::GoalPolicy.new(user: nil, profile_owner: user)
+      goals = policy.apply_scope(Goal.all, type: :active_record_relation)
+
+      assert_equal [ public_goal ], goals
+    end
+
+    test "other users can only see public goals" do
+      user = create(:user)
+      other_user = create(:user)
+      public_goal = create(:goal, :public, user:)
+      _private_goal = create(:goal, :private, user:)
+
+      create(:goal)
+
+      policy = Profiles::GoalPolicy.new(user: other_user, profile_owner: user)
+      goals = policy.apply_scope(Goal.all, type: :active_record_relation)
+
+      assert_equal [ public_goal ], goals
+    end
+  end
+end


### PR DESCRIPTION
Adiciona listagem de metas no perfil do usuário. Quando o usuário logado é o dono do perfil, as metas mostram um dropdown.

**O que o dono do perfil vê:**
![image](https://github.com/user-attachments/assets/183cfbd6-656e-4a39-8549-a31d4304fb0b)

**O que os visitantes do perfil veem:**
![image](https://github.com/user-attachments/assets/32015ebe-d945-4bdd-b6ca-af96c923875e)

**O que o dono do perfil vê quando não há metas cadastradas:**
![image](https://github.com/user-attachments/assets/7a9bc026-4a71-4e30-a9cc-da66a49ff81e)

**O que o vistantes veem quando não há metas cadastradas:**
![image](https://github.com/user-attachments/assets/f50992f5-7c0b-404b-a18e-135956bbd674)


