### PR TITLE
feat: Add the daily goals progress model

### DIFF
--- a/app/models/daily_goals_progress.rb
+++ b/app/models/daily_goals_progress.rb
@@ -1,0 +1,41 @@
+class DailyGoalsProgress
+  include ActiveModel::Model
+
+  attr_accessor :date, :updates, :user_id
+
+  def self.where(**args)
+    scope = base_scope
+    scope = scope.where(**args) if args.size.positive?
+    map_scope_to_models(scope)
+  end
+
+  private
+  def self.base_scope
+    Goal::ProgressChange
+      .joins(goal: :user)
+      .group(*group_by_columns)
+  end
+
+  def self.map_scope_to_models(scope)
+    scope
+      .pluck(*selected_columns)
+      .map do |updates, date, user_id|
+        new(date: date.to_date, updates:, user_id:)
+      end
+  end
+
+  def self.group_by_columns
+    [
+      "DATE(goal_progress_changes.CREATED_AT, 'localtime')",
+      :user_id
+    ]
+  end
+
+  def self.selected_columns
+    [
+      Arel.sql("COUNT(*) AS updates"),
+      Arel.sql("DATE(goal_progress_changes.CREATED_AT, 'localtime') AS date"),
+      :user_id
+    ]
+  end
+end

--- a/test/factories/goal/progress_changes.rb
+++ b/test/factories/goal/progress_changes.rb
@@ -1,4 +1,7 @@
 FactoryBot.define do
   factory :goal_progress_change, class: "Goal::ProgressChange" do
+    new_value { 10 }
+    old_value { 0 }
+    target { 10 }
   end
 end

--- a/test/models/daily_goals_progress_test.rb
+++ b/test/models/daily_goals_progress_test.rb
@@ -1,0 +1,122 @@
+require "test_helper"
+
+class DailyGoalsProgressTest < ActiveSupport::TestCase
+  test "the query result is mapped to an array of DailyGoalsProgress" do
+    goal = create(:goal)
+    create(:goal_progress_change, goal:)
+
+    assert_instance_of DailyGoalsProgress, DailyGoalsProgress.where.first
+  end
+
+  test "the goal progress changes are grouped by date and user id" do
+    # user 1
+    user1 = create(:user)
+
+    goal1 = create(:goal, user: user1)
+    create(:goal_progress_change, goal: goal1, created_at: Date.new(2025, 1, 1))
+
+    goal2 = create(:goal, user: user1)
+    create(:goal_progress_change, goal: goal2, created_at: Date.new(2025, 1, 1))
+
+    goal2 = create(:goal, user: user1)
+    create(:goal_progress_change, goal: goal2, created_at: Date.new(2025, 1, 2))
+
+    # user 2
+    user2 = create(:user)
+
+    goal3 = create(:goal, user: user2)
+    create(:goal_progress_change, goal: goal3, created_at: Date.new(2025, 1, 1))
+
+    expected_result = [
+      {
+        date: Date.new(2025, 1, 1),
+        updates: 2,
+        user_id: user1.id
+      },
+      {
+        date: Date.new(2025, 1, 2),
+        updates: 1,
+        user_id: user1.id
+      },
+      {
+        date: Date.new(2025, 1, 1),
+        updates: 1,
+        user_id: user2.id
+      }
+    ]
+
+    result = DailyGoalsProgress.where.map do
+      {
+        date: it.date,
+        updates: it.updates,
+        user_id: it.user_id
+      }
+    end
+
+    assert_equal 3, result.size
+    assert_equal expected_result.to_set, result.to_set
+  end
+
+  test "the result aggregates goal progress change ocurrences for each day" do
+    # user 1
+    user1 = create(:user)
+
+    goal1 = create(:goal, user: user1)
+    create(:goal_progress_change, goal: goal1, created_at: Date.new(2025, 1, 1))
+
+    goal2 = create(:goal, user: user1)
+    create(:goal_progress_change, goal: goal2, created_at: Date.new(2025, 1, 1))
+
+    goal3 = create(:goal, user: user1)
+    create(:goal_progress_change, goal: goal3, created_at: Date.new(2025, 1, 2))
+
+    result = DailyGoalsProgress.where.sort_by { it.date }
+
+    assert_equal 2, result.size
+
+    assert_equal Date.new(2025, 1, 1), result.first.date
+    assert_equal 2, result.first.updates
+
+    assert_equal Date.new(2025, 1, 2), result.second.date
+    assert_equal 1, result.second.updates
+  end
+
+  test "results can be filtered by user id" do
+    # user 1
+    user1 = create(:user)
+
+    goal1 = create(:goal, user: user1)
+    create(:goal_progress_change, goal: goal1, created_at: Date.new(2025, 1, 1))
+
+    goal2 = create(:goal, user: user1)
+    create(:goal_progress_change, goal: goal2, created_at: Date.new(2025, 1, 1))
+
+    goal2 = create(:goal, user: user1)
+    create(:goal_progress_change, goal: goal2, created_at: Date.new(2025, 1, 2))
+
+    # user 2
+    user2 = create(:user)
+
+    goal3 = create(:goal, user: user2)
+    create(:goal_progress_change, goal: goal3, created_at: Date.new(2025, 1, 1))
+
+    expected_result = [
+      {
+        date: Date.new(2025, 1, 1),
+        updates: 1,
+        user_id: user2.id
+      }
+    ]
+
+    result = DailyGoalsProgress.where(goal: { user_id: user2.id }).map do
+      {
+        date: it.date,
+        updates: it.updates,
+        user_id: it.user_id
+      }
+    end
+
+    assert_equal 1, result.size
+    assert_equal expected_result.to_set, result.to_set
+  end
+end


### PR DESCRIPTION
Adiciona o objeto `DailyGoalsProgress` que representa o resultado da agregação de goal change progresses. O objeto implementa o método `#where` que agrega os goal progress changes e mapeia eles  para o objeto `DailyGoalsProgress`.

Esse objeto permite calcular quantas atualizações de progresso cada usuário fez e em quais dias elas aconteceram.