### PR TITLE
fix: Follow button does not update

### DIFF
--- a/app/controllers/feed_controller.rb
+++ b/app/controllers/feed_controller.rb
@@ -8,7 +8,7 @@ class FeedController < DashboardController
 
     respond_to do |format|
       format.html
-      format.turbo_stream
+      format.turbo_stream if params[:load_more]
     end
   end
 end

--- a/app/controllers/profiles/goals_controller.rb
+++ b/app/controllers/profiles/goals_controller.rb
@@ -5,6 +5,11 @@ module Profiles
     def index
       scope = authorized_scope(Goal.all.order(created_at: :desc), with: Profiles::GoalPolicy)
       @pagy, @goals = pagy(scope)
+
+      respond_to do |format|
+        format.html
+        format.turbo_stream if params[:load_more]
+      end
     end
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -15,7 +15,7 @@ class ProfilesController < ApplicationController
 
     respond_to do |format|
       format.html
-      format.turbo_stream
+      format.turbo_stream if params[:load_more]
     end
   end
 

--- a/app/views/feed/_next_page.html.erb
+++ b/app/views/feed/_next_page.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :next_page, src: feed_index_path(format: :turbo_stream, page: pagy.next), loading: :lazy do %>
+<%= turbo_frame_tag :next_page, src: feed_index_path(format: :turbo_stream, page: pagy.next, load_more: true), loading: :lazy do %>
   <div class="flex items-center justify-center">
     <span class="text-zinc-500 dark:text-zinc-300">
       <%= t(".loading") %>

--- a/app/views/profiles/_next_page.html.erb
+++ b/app/views/profiles/_next_page.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :next_page, src: profile_path(user.username, format: :turbo_stream, page: pagy.next), loading: :lazy do %>
+<%= turbo_frame_tag :next_page, src: profile_path(user.username, format: :turbo_stream, page: pagy.next, load_more: true), loading: :lazy do %>
   <div class="flex items-center justify-center">
     <span class="text-zinc-500 dark:text-zinc-300">
       <%= t(".loading") %>

--- a/app/views/profiles/goals/_next_page.html.erb
+++ b/app/views/profiles/goals/_next_page.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :next_page, src: profile_goals_path(@user.username, format: :turbo_stream, page: pagy.next), loading: :lazy do %>
+<%= turbo_frame_tag :next_page, src: profile_goals_path(@user.username, format: :turbo_stream, page: pagy.next, load_more: true), loading: :lazy do %>
   <div class="flex items-center justify-center">
     <span class="text-zinc-500 dark:text-zinc-300">
       <%= t(".loading") %>


### PR DESCRIPTION
Corrige o comportamento do botão de seguir. Atualmente, depois que o botão é clicado, a página não atualiza e o botão permanece igual. O comportamento esperado é que o botão mudasse de `Seguir` para `Parar de seguir`.

Esse problema aconteceu, porque, depois que a rota de seguir usuário é chamada, ocorre um redirect para o perfil do usuário no formato `turbo_stream`, o que faz o controller de posts adicionar novos posts no feed do perfil ao invés de atualizar a página.