### PR TITLE
feat: Implement notification components

### DIFF
--- a/app/components/features/notifications/item_component.html.erb
+++ b/app/components/features/notifications/item_component.html.erb
@@ -1,0 +1,5 @@
+<div class="px-4 py-4 flex items-center justify-between gap-2 group">
+  <div class="w-full">
+    <%= render component_type.new(record: record) %>
+  </div>
+</div>

--- a/app/components/features/notifications/item_component.rb
+++ b/app/components/features/notifications/item_component.rb
@@ -5,25 +5,24 @@ module Notifications
     def initialize(user_notification:, **user_attrs)
       @user_notification = user_notification
       @notification = @user_notification.notification
-      @notifiable = @notification.notifiable
       super(**user_attrs)
     end
 
     private
 
-    attr_reader :notification, :notifiable
+    attr_reader :notification
 
     def component_type
-      "Notifications::Types::#{notifiable_type}Component".constantize
+      "Notifications::Types::#{notifiable_type.classify}Component".constantize
     end
 
     def record
-      record = { notification_like: notifiable.entry_like }
-      record[notifiable_type.param_key.to_sym]
+      record = { notification_like: notification.notifiable.entry_like }
+      record[notifiable_type.to_sym]
     end
 
     def notifiable_type
-      notifiable.model_name
+      notification.notifiable_name
     end
   end
 end

--- a/app/components/features/notifications/item_component.rb
+++ b/app/components/features/notifications/item_component.rb
@@ -1,0 +1,29 @@
+module Notifications
+  class ItemComponent < ApplicationComponent
+    with_collection_parameter :user_notification
+
+    def initialize(user_notification:, **user_attrs)
+      @user_notification = user_notification
+      @notification = @user_notification.notification
+      @notifiable = @notification.notifiable
+      super(**user_attrs)
+    end
+
+    private
+
+    attr_reader :notification, :notifiable
+
+    def component_type
+      "Notifications::Types::#{notifiable_type}Component".constantize
+    end
+
+    def record
+      record = { notification_like: notifiable.entry_like }
+      record[notifiable_type.param_key.to_sym]
+    end
+
+    def notifiable_type
+      notifiable.model_name
+    end
+  end
+end

--- a/app/components/features/notifications/list_component.html.erb
+++ b/app/components/features/notifications/list_component.html.erb
@@ -1,0 +1,39 @@
+<div class="md:flex justify-end md:flex-1 md:mr-4 mr-3 relative" data-controller="railsui-dropdown">
+  <%= render UI::Button::Component.new(
+    variant: :rounded_outlined,
+    color: :dark,
+    class: "md:w-10 md:h-10 w-12 h-12",
+    data: { action: "click->railsui-dropdown#toggle click@window->railsui-dropdown#hide" }
+  ) do %>
+    <div class="relative">
+      <%= render UI::Icon::Component.new("bell", class: "md:w-5 md:h-5 w-6 h-6") %>
+
+      <% if unread_notifications? %>
+        <%= tag.span(class: style(:unread_indicator)) %>
+      <% end %>
+    </div>
+  <% end %>
+
+  <%= tag.div(
+      class: style(:list_wrapper),
+      data: {
+        dropdown_target: "menu",
+        transition_enter_from: "opacity-0 scale-95",
+        transition_enter_to: "opacity-100 scale-100",
+        transition_leave_from: "opacity-100 scale-100",
+        transition_leave_to: "opacity-0 scale-95",
+        railsui_dropdown_target: "menu"
+      }
+    ) do %>
+    <% if user_notifications.any? %>
+      <%= render Notifications::ItemComponent.with_collection(user_notifications) %>
+
+      <%= link_to(href, class: style(:view_all_button)) do %>
+        <span> <%= t(".see_all") %> </span>
+        <%= render UI::Icon::Component.new("chevron-right", class: "w-4 h-4") %>
+      <% end %>
+    <% else %>
+      <p class="text-center py-2"><%= t(".empty_state_message") %></p>
+    <% end %>
+  <% end %>
+</div>

--- a/app/components/features/notifications/list_component.rb
+++ b/app/components/features/notifications/list_component.rb
@@ -1,0 +1,48 @@
+module Notifications
+  class ListComponent < ApplicationComponent
+    style :unread_indicator do
+      base do
+        %w[w-2 h-2 bg-red-500 rounded-full hover:animate-pulse absolute top-0
+          right-0 z-20 dark:bg-primary-500/95
+        ]
+      end
+    end
+
+    style :list_wrapper do
+      base do
+        %w[origin-to-right md:absolute mt-2 ml-2 md:ml-0 md:mt-0 md:shadow-xl sm:w-[360px]
+          md:min-w-[360px] divide-y text-left dark:divide-zinc-700 transition transform
+          md:origin-top-right origin-top-left absolute right-0 top-12 bg-white rounded-lg
+          shadow-xl shadow-zinc-900/10 border border-zinc-200 md:w-[320px] w-full z-50
+          dark:bg-zinc-900 dark:shadow-zinc-900/50 dark:border-zinc-500/60
+          md:text-sm text-base font-medium text-zinc-600 dark:text-zinc-200
+        ]
+      end
+    end
+
+    style :view_all_button do
+      base do
+        %w[flex items-center justify-between group px-4 py-4
+          hover:text-primary-500 text-sm group font-medium text-zinc-500
+          dark:text-zinc-200 dark:hover:bg-zinc-800 dark:hover:text-white
+        ]
+      end
+    end
+
+    def initialize(user_notifications: [], href: "#",**user_attrs)
+      @user_notifications = user_notifications
+      @href = href
+      super(**user_attrs)
+    end
+
+    private
+
+    attr_reader :user_notifications, :href
+
+    def unread_notifications?
+      return if user_notifications.empty?
+
+      user_notifications.where.not(read_at: nil).exists?
+    end
+  end
+end

--- a/app/components/features/notifications/list_component.rb
+++ b/app/components/features/notifications/list_component.rb
@@ -29,7 +29,7 @@ module Notifications
       end
     end
 
-    def initialize(user_notifications: [], href: "#",**user_attrs)
+    def initialize(user_notifications: [], href: "#", **user_attrs)
       @user_notifications = user_notifications
       @href = href
       super(**user_attrs)

--- a/app/components/features/notifications/list_component.rb
+++ b/app/components/features/notifications/list_component.rb
@@ -42,7 +42,7 @@ module Notifications
     def unread_notifications?
       return if user_notifications.empty?
 
-      user_notifications.where.not(read_at: nil).exists?
+      user_notifications.where(read_at: nil).exists?
     end
   end
 end

--- a/app/components/features/notifications/types/notification_like_component.html.erb
+++ b/app/components/features/notifications/types/notification_like_component.html.erb
@@ -1,0 +1,12 @@
+<div class="flex items-start space-x-2">
+  <%= render UI::Avatar::Component.new(src: user.avatar.variant(:thumb), size: :sm) %>
+
+  <div class="flex-1">
+    <p class="truncate">
+      <%= user.name %> <%= t(".entry_#{entry_type}") %>
+    </p>
+    <p class="text-xs text-zinc-500 dark:text-zinc-400">
+      <%= time_ago_in_words(record.created_at) + t(".ago") %>
+    </p>
+  </div>
+</div>

--- a/app/components/features/notifications/types/notification_like_component.html.erb
+++ b/app/components/features/notifications/types/notification_like_component.html.erb
@@ -2,7 +2,7 @@
   <%= render UI::Avatar::Component.new(src: user.avatar.variant(:thumb), size: :sm) %>
 
   <div class="flex-1">
-    <p class="truncate">
+    <p class="truncate font-semibold">
       <%= user.name %> <%= t(".entry_#{entry_type}") %>
     </p>
     <p class="text-xs text-zinc-500 dark:text-zinc-400">

--- a/app/components/features/notifications/types/notification_like_component.rb
+++ b/app/components/features/notifications/types/notification_like_component.rb
@@ -1,0 +1,19 @@
+module Notifications
+  module Types
+    class NotificationLikeComponent < ApplicationComponent
+      def initialize(record:, **user_attrs)
+        @record = record
+        @user = record.user
+        super(**user_attrs)
+      end
+
+      private
+
+      attr_reader :record, :user
+
+      def entry_type
+        record.entry.entryable.model_name.param_key
+      end
+    end
+  end
+end

--- a/app/components/features/notifications/types/notification_like_component.rb
+++ b/app/components/features/notifications/types/notification_like_component.rb
@@ -12,7 +12,7 @@ module Notifications
       attr_reader :record, :user
 
       def entry_type
-        record.entry.entryable.model_name.param_key
+        record.entry.entryable_name
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,7 @@ class User < ApplicationRecord
   has_many :goals, dependent: :destroy
   has_many :entries, dependent: :destroy, foreign_key: "owner_id"
   has_many :follow_requests, dependent: :destroy, foreign_key: "followee_id"
+  has_many :user_notifications, dependent: :destroy
 
   validates :first_name, presence: true
   validates :last_name, presence: true

--- a/config/locales/pt-BR/features.yml
+++ b/config/locales/pt-BR/features.yml
@@ -8,7 +8,7 @@ pt-BR:
           remaining: Restante
       progress_calendar:
         component:
-          updates: 
+          updates:
             zero: "%{count} atualizações de progresso em %{date}"
             one: "%{count} atualização de progresso em %{date}"
             other: "%{count} atualizações de progresso em %{date}"
@@ -17,3 +17,12 @@ pt-BR:
         component:
           loading: Carregando...
           likes: "%{count} kudos"
+    notifications:
+      types:
+        notification_like_component:
+          ago: " atrás"
+          entry_post: deu kudos em sua publicação
+          entry_comment: deu kudos em seu comentário
+      list_component:
+        empty_state_message: Você não possui notificações
+        see_all: Ver todas as notificações

--- a/test/components/features/notifications/item_component_test.rb
+++ b/test/components/features/notifications/item_component_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+module Notifications
+  class ItemComponentTest < ViewComponent::TestCase
+    test "renders" do
+      user = build_stubbed(:user)
+      record = build_stubbed(:entry_like, user:)
+
+      notifiable = build_stubbed(:notification_like, entry_like: record)
+      notification = build_stubbed(:notification, notifiable:)
+      user_notification = build_stubbed(:user_notification, user:, notification:)
+
+      item_component = render_inline(Notifications::ItemComponent.new(user_notification:))
+      notification_type_component = render_inline(Notifications::Types::NotificationLikeComponent.new(record:))
+
+      assert_includes item_component.to_html, notification_type_component.to_html
+    end
+  end
+end

--- a/test/components/features/notifications/list_component_test.rb
+++ b/test/components/features/notifications/list_component_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+module Notifications
+  class ListComponentTest < ViewComponent::TestCase
+    test "renders without notifications" do
+      render_inline(Notifications::ListComponent.new(user_notifications: []))
+
+      assert_text I18n.t("features.notifications.list_component.empty_state_message")
+      assert_no_text I18n.t("features.notifications.list_component.see_all")
+    end
+
+    test "renders with read notifications" do
+      user = create(:user)
+      user_notification = create(:user_notification, :read, user:)
+
+      render_inline(Notifications::ListComponent.new(
+          user_notifications: user.user_notifications,
+          href: "https://example.com"
+        )
+      )
+
+      assert_no_selector "span.bg-red-500"
+      assert_link href: "https://example.com"
+      assert_text I18n.t("features.notifications.list_component.see_all")
+      assert_no_text I18n.t("features.notifications.list_component.empty_state_message")
+    end
+
+    test "renders with unread notifications" do
+      user = create(:user)
+      user_notification = create(:user_notification, user:)
+
+      render_inline(Notifications::ListComponent.new(
+          user_notifications: user.user_notifications,
+          href: "https://example.com"
+        )
+      )
+
+      assert_selector "span.bg-red-500"
+    end
+  end
+end

--- a/test/components/features/notifications/types/notification_like_component_test.rb
+++ b/test/components/features/notifications/types/notification_like_component_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+module Notifications
+  module Types
+    class NotificationLikeComponentTest < ViewComponent::TestCase
+      test "renders" do
+        user = build_stubbed(:user)
+        record = build_stubbed(:entry_like, user:)
+
+        render_inline(Notifications::Types::NotificationLikeComponent.new(record:))
+
+        assert_selector "img"
+        assert_text user.name
+        assert_text(
+          I18n.t("features.notifications.types.notification_like_component.entry_post")
+        )
+      end
+    end
+  end
+end

--- a/test/factories/entry/likes.rb
+++ b/test/factories/entry/likes.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :entry_like, class: "Entry::Like" do
-    entry
+    entry { create(:entry, :post) }
     user
   end
 end

--- a/test/factories/notifications.rb
+++ b/test/factories/notifications.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :notification do
-    notifiable { "NotificationLike" }
+    notifiable { create(:notification_like) }
   end
 end

--- a/test/factories/user_notifications.rb
+++ b/test/factories/user_notifications.rb
@@ -2,9 +2,9 @@ FactoryBot.define do
   factory :user_notification do
     association :user
     association :notification
-  end
 
-  trait :read do
-    read_at { Time.zone.now }
+    trait :read do
+      read_at { Time.zone.now }
+    end
   end
 end


### PR DESCRIPTION
Quando o usuário possui notificações:
<img width="402" alt="Captura de Tela 2025-03-16 às 16 17 12" src="https://github.com/user-attachments/assets/677ec726-4291-447a-88b3-b21491d624f0" />

Quando o usuário não possui notificações:
<img width="388" alt="Captura de Tela 2025-03-16 às 16 17 34" src="https://github.com/user-attachments/assets/4b057eb1-86ea-421f-a925-4dbe3a1e0ef1" />

Débitos técnicos para o próximo PR:

- Ajustar o nome da relação de User e UserNotification para ficar apenas "user_notification" (só mexi pq precisava incluir essa relação pro teste passar)
- Ajustar as factories (a ideia é criar traits com as opções de notifiable igual como está as de entries)