### PR TITLE
feat: Add counter input to progress update

### DIFF
--- a/app/components/ui/counter/button_component.rb
+++ b/app/components/ui/counter/button_component.rb
@@ -5,7 +5,7 @@ module UI
         base do
           %(
             btn btn-white rounded-full w-8 h-8 flex items-center
-            justify-center p-0 cursor-pointer
+            justify-center p-0 cursor-pointer shrink-0 shadow-none
           )
         end
       end

--- a/app/javascript/controllers/railsui/counter_input_controller.js
+++ b/app/javascript/controllers/railsui/counter_input_controller.js
@@ -16,6 +16,7 @@ export default class extends Controller {
     // Increment value by 1
     this.valueTarget.value = parseValue(this.valueTarget.value) + 1
     this.disableDecrementIfZero()
+    this.notifyChange()
   }
 
   decrement(event) {
@@ -23,6 +24,7 @@ export default class extends Controller {
     // Decrement value by 1, but ensure it doesn't go below 0
     this.valueTarget.value = Math.max(parseValue(this.valueTarget.value) - 1, 0)
     this.disableDecrementIfZero()
+    this.notifyChange()
   }
 
   disableDecrementIfZero() {
@@ -36,5 +38,9 @@ export default class extends Controller {
       )
       this.decrementBtnTarget.removeAttribute('disabled')
     }
+  }
+
+  notifyChange() {
+    this.dispatch('change', { value: this.valueTarget.value })
   }
 }

--- a/app/javascript/controllers/sum_updater_controller.js
+++ b/app/javascript/controllers/sum_updater_controller.js
@@ -1,19 +1,23 @@
-import { Controller } from "@hotwired/stimulus";
+import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
-  static targets = ["output", "fieldOutput"];
+  static targets = ['input', 'output', 'fieldOutput']
   static values = {
     base: {
       type: Number,
       default: 0,
     },
-  };
+  }
 
-  update({ target }) {
-    const valueChange = parseFloat(target.value) || 0;
-    const result = this.baseValue + valueChange;
+  update() {
+    if (!this.hasInputTarget) {
+      return
+    }
 
-    this.outputTargets.forEach((output) => (output.innerText = result));
-    this.fieldOutputTargets.forEach((output) => (output.value = result));
+    const valueChange = parseFloat(this.inputTarget.value) || 0
+    const result = this.baseValue + valueChange
+
+    this.outputTargets.forEach((output) => (output.innerText = result))
+    this.fieldOutputTargets.forEach((output) => (output.value = result))
   }
 }

--- a/app/views/goals/update_progresses/edit.html.erb
+++ b/app/views/goals/update_progresses/edit.html.erb
@@ -31,15 +31,24 @@
         class: "text-left", 
       ) do %>
         <%= form.form_group :current do %>
-          <%= render Form::TextField::Component.new(
-            placeholder: 0,
-            required: true,
-            class: "text-center",
+          <%= render UI::Counter::Component.new(
             data: {
-              action: "input->sum-updater#update",
-            },
-            onenter: "this.form.requestSubmit()",
-          ) %>
+              action: "counter-input:change->sum-updater#update",
+            }
+          ) do |counter| %>
+            <% counter.with_decrement_button %>
+            <% counter.with_increment_button %>
+            <% counter.with_input(
+              placeholder: 0,
+              required: true,
+              class: "text-center",
+              onenter: "this.form.requestSubmit()",
+              class: "w-full",
+              data: {
+                sum_updater_target: "input",
+              },
+            ) %>
+          <% end %>
         <% end %>
 
         <div>


### PR DESCRIPTION
Adiciona o input `counter` no modal de atualizar progresso da meta:

![image](https://github.com/user-attachments/assets/585c3d7e-99ef-4898-b8ef-8ec0a338bd51)
