### PR TITLE
feat: Add mentions to posts and entries

### DIFF
--- a/app/jobs/entry/mention_syncer_job.rb
+++ b/app/jobs/entry/mention_syncer_job.rb
@@ -1,0 +1,7 @@
+class Entry::MentionSyncerJob < ApplicationJob
+  queue_as :default
+
+  def perform(entry)
+    Entry::MentionSyncer.new(entry).sync
+  end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -6,7 +6,7 @@ class Comment < ApplicationRecord
 
   validates :body, presence: true, length: { maximum: 2200 }
 
-  def mentioned_handles
+  def extract_handles
     HandleTextParser.new(body).parse
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -5,4 +5,8 @@ class Comment < ApplicationRecord
   has_one :owner, through: :entry
 
   validates :body, presence: true, length: { maximum: 2200 }
+
+  def mentioned_handles
+    HandleTextParser.new(body).parse
+  end
 end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -2,6 +2,7 @@ class Entry < ApplicationRecord
   FEED_ENTRIES = %w[ Post ]
 
   delegated_type :entryable, types: %w[ Post Comment ], dependent: :destroy
+  delegate :mentioned_handles, to: :entryable
 
   has_many :likes, dependent: :destroy
   has_many :comments, dependent: :destroy, inverse_of: :parent
@@ -37,5 +38,9 @@ class Entry < ApplicationRecord
     return if user.blank?
 
     likes.find_by(user_id: user.id)
+  end
+
+  def sync_mentions_later
+    MentionSyncerJob.perform_later(self)
   end
 end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -2,11 +2,12 @@ class Entry < ApplicationRecord
   FEED_ENTRIES = %w[ Post ]
 
   delegated_type :entryable, types: %w[ Post Comment ], dependent: :destroy
-  delegate :mentioned_handles, to: :entryable
+  delegate :extract_handles, to: :entryable
 
   has_many :likes, dependent: :destroy
   has_many :comments, dependent: :destroy, inverse_of: :parent
   has_many :mentions, dependent: :destroy, inverse_of: :entry, foreign_key: :entry_id
+  has_many :mentioned_users, through: :mentions, source: :mentionee
 
   belongs_to :owner, class_name: "User", foreign_key: :owner_id
 
@@ -42,5 +43,9 @@ class Entry < ApplicationRecord
 
   def sync_mentions_later
     MentionSyncerJob.perform_later(self)
+  end
+
+  def mentioned_handles
+    mentioned_users.map { Handle.new(it.handle) }
   end
 end

--- a/app/models/entry/mention_cleaner.rb
+++ b/app/models/entry/mention_cleaner.rb
@@ -1,0 +1,22 @@
+class Entry::MentionCleaner
+  def initialize(entry)
+    @entry = entry
+  end
+
+  def clean
+    removed_mentions.destroy_all
+  end
+
+  private
+  def removed_mentions
+    @entry.mentions
+          .joins(:mentionee)
+          .where(mentionee: User.where(username: removed_handles.map(&:username)))
+  end
+
+  def removed_handles
+    @entry.mentioned_handles.reject do |handle|
+      @entry.extract_handles.include?(handle)
+    end
+  end
+end

--- a/app/models/entry/mention_importer.rb
+++ b/app/models/entry/mention_importer.rb
@@ -1,0 +1,26 @@
+class Entry::MentionImporter
+  def initialize(entry)
+    @entry = entry
+  end
+
+  def import
+    new_mentions.each(&:save)
+  end
+
+  private
+  def new_mentions
+    new_mentioned_users.map do |user|
+      @entry.mentions.build(mentionee: user, mentioner: @entry.owner)
+    end
+  end
+
+  def new_mentioned_users
+    @_new_mentioned_users ||= @entry.owner
+                                    .followers
+                                    .where(username: new_mentioned_handles.map(&:username))
+  end
+
+  def new_mentioned_handles
+    @entry.extract_handles.uniq - @entry.mentioned_handles
+  end
+end

--- a/app/models/entry/mention_syncer.rb
+++ b/app/models/entry/mention_syncer.rb
@@ -1,0 +1,57 @@
+class Entry::MentionSyncer
+  def initialize(entry)
+    @entry = entry
+  end
+
+  def sync
+    destroy_removed_mentions
+    create_new_mentions
+  end
+
+  private
+  def destroy_removed_mentions
+    removed_mentions.destroy_all
+  end
+
+  def create_new_mentions
+    new_mentions.each(&:save)
+  end
+
+  def new_mentions
+    new_mentioned_users.map do |user|
+      @entry.mentions.build(mentionee: user, mentioner: @entry.owner)
+    end
+  end
+
+  def new_mentioned_users
+    @_new_mentioned_users ||= @entry.owner
+                                    .followers
+                                    .where(username: new_mentioned_handles.map(&:username))
+  end
+
+  def new_mentioned_handles
+    current_mentioned_handles
+      .reject { existing_mentioned_usernames.include?(it.username) }
+  end
+
+  def current_mentioned_handles
+    @_handlers ||= @entry.mentioned_handles.uniq.to_set
+  end
+
+  def removed_mentions
+    @entry.mentions
+          .joins(:mentionee)
+          .where(mentionee: User.where(username: removed_mentioned_usernames))
+  end
+
+  def removed_mentioned_usernames
+    existing_mentioned_usernames - current_mentioned_handles.map(&:username)
+  end
+
+  def existing_mentioned_usernames
+    @_existing_mentioned_usernames = @entry.mentions
+                                           .joins(:mentionee)
+                                           .pluck(:username)
+                                           .to_set
+  end
+end

--- a/app/models/entry/mention_syncer.rb
+++ b/app/models/entry/mention_syncer.rb
@@ -4,54 +4,7 @@ class Entry::MentionSyncer
   end
 
   def sync
-    destroy_removed_mentions
-    create_new_mentions
-  end
-
-  private
-  def destroy_removed_mentions
-    removed_mentions.destroy_all
-  end
-
-  def create_new_mentions
-    new_mentions.each(&:save)
-  end
-
-  def new_mentions
-    new_mentioned_users.map do |user|
-      @entry.mentions.build(mentionee: user, mentioner: @entry.owner)
-    end
-  end
-
-  def new_mentioned_users
-    @_new_mentioned_users ||= @entry.owner
-                                    .followers
-                                    .where(username: new_mentioned_handles.map(&:username))
-  end
-
-  def new_mentioned_handles
-    current_mentioned_handles
-      .reject { existing_mentioned_usernames.include?(it.username) }
-  end
-
-  def current_mentioned_handles
-    @_handlers ||= @entry.mentioned_handles.uniq.to_set
-  end
-
-  def removed_mentions
-    @entry.mentions
-          .joins(:mentionee)
-          .where(mentionee: User.where(username: removed_mentioned_usernames))
-  end
-
-  def removed_mentioned_usernames
-    existing_mentioned_usernames - current_mentioned_handles.map(&:username)
-  end
-
-  def existing_mentioned_usernames
-    @_existing_mentioned_usernames = @entry.mentions
-                                           .joins(:mentionee)
-                                           .pluck(:username)
-                                           .to_set
+    Entry::MentionImporter.new(@entry).import
+    Entry::MentionCleaner.new(@entry).clean
   end
 end

--- a/app/models/handle.rb
+++ b/app/models/handle.rb
@@ -1,0 +1,27 @@
+class Handle
+  HANDLE_PATTERN = /\A@[a-zA-Z0-9_]([a-zA-Z0-9_]|\.[a-zA-Z0-9_])+\z/
+
+  attr_reader :value
+
+  def initialize(value)
+    raise ArgumentError, "Invalid handle" unless value.match?(HANDLE_PATTERN)
+
+    @value = value
+  end
+
+  def username
+    value[1..]
+  end
+
+  def self.from_username(username)
+    new("@#{username}")
+  end
+
+  def to_s
+    value
+  end
+
+  def ==(other)
+    other.is_a?(Handle) && value == other.value
+  end
+end

--- a/app/models/handle.rb
+++ b/app/models/handle.rb
@@ -21,7 +21,11 @@ class Handle
     value
   end
 
-  def ==(other)
+  def eql?(other)
     other.is_a?(Handle) && value == other.value
+  end
+
+  def ==(other)
+    eql?(other)
   end
 end

--- a/app/models/handle_text_parser.rb
+++ b/app/models/handle_text_parser.rb
@@ -1,0 +1,11 @@
+class HandleTextParser
+  HANDLE_PATTERN = /(@[a-zA-Z0-9_]([a-zA-Z0-9_]|\.[a-zA-Z0-9_])+)/
+
+  def initialize(text)
+    @text = text
+  end
+
+  def parse
+    @text.scan(HANDLE_PATTERN).map { Handle.new(it.first) }
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -20,7 +20,7 @@ class Post < ApplicationRecord
             limit: { max: 5, message: :limit },
             size: { less_than_or_equal_to: 8.megabytes, message: :size }
 
-  def mentioned_handles
+  def extract_handles
     HandleTextParser.new(body).parse
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -19,4 +19,8 @@ class Post < ApplicationRecord
             },
             limit: { max: 5, message: :limit },
             size: { less_than_or_equal_to: 8.megabytes, message: :size }
+
+  def mentioned_handles
+    HandleTextParser.new(body).parse
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  USERNAME_PATTERN = /\A[a-zA-Z0-9_]([a-zA-Z0-9_]|\.[a-zA-Z0-9_])+\z/
+
   include Followable, CurrentPassword
 
   has_secure_password
@@ -23,6 +25,8 @@ class User < ApplicationRecord
   validates :first_name, length: { maximum: 255 }
   validates :last_name, length: { maximum: 255 }
   validates :username, length: { maximum: 255 }
+
+  validate :username_format
 
   normalizes :email_address, with: ->(e) { e.strip.downcase }
 
@@ -61,5 +65,11 @@ class User < ApplicationRecord
       self.username = self.username.first(248)
       self.username += ".#{SecureRandom.hex(3)}"
     end
+  end
+
+  def username_format
+    return if username.blank?
+
+    errors.add(:username, :invalid) unless username.match?(USERNAME_PATTERN)
   end
 end

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -7,10 +7,10 @@ class CommentTest < ActiveSupport::TestCase
   should validate_presence_of(:body)
   should validate_length_of(:body).is_at_most(2200)
 
-  test "mentioned_handles" do
+  test "extract_handles" do
     entry = create(:entry, :post)
     comment = create(:comment, parent: entry, body: "Hello @user, @user2.")
 
-    assert_equal [ Handle.new("@user"), Handle.new("@user2") ], comment.mentioned_handles
+    assert_equal [ Handle.new("@user"), Handle.new("@user2") ], comment.extract_handles
   end
 end

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -6,4 +6,11 @@ class CommentTest < ActiveSupport::TestCase
 
   should validate_presence_of(:body)
   should validate_length_of(:body).is_at_most(2200)
+
+  test "mentioned_handles" do
+    entry = create(:entry, :post)
+    comment = create(:comment, parent: entry, body: "Hello @user, @user2.")
+
+    assert_equal [ Handle.new("@user"), Handle.new("@user2") ], comment.mentioned_handles
+  end
 end

--- a/test/models/entry/mention_cleaner_test.rb
+++ b/test/models/entry/mention_cleaner_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class Entry::MentionCleanerTest < ActiveSupport::TestCase
+  test "destroys removed mentions" do
+    user1 = create(:user, username: "user1")
+    user2 = create(:user, username: "user2")
+    user3 = create(:user, username: "user3")
+
+    create(:follow, follower: user2, followee: user1)
+    create(:follow, follower: user3, followee: user1)
+
+    post = create(:post, body: "Hello @user2, @user3.")
+    entry = create(:entry, entryable: post, owner: user1)
+
+    create(:mention, entry:, mentioner: user1, mentionee: user2)
+    create(:mention, entry:, mentioner: user1, mentionee: user3)
+
+    post.update!(body: "Hello @user2.")
+
+    assert_difference "Mention.count", -1 do
+      Entry::MentionCleaner.new(entry).clean
+    end
+
+    assert_equal [ user2 ], entry.mentions.map(&:mentionee)
+  end
+
+  test "does not destroy mentions of other users" do
+    user1 = create(:user, username: "user1")
+    user2 = create(:user, username: "user2")
+    user3 = create(:user, username: "user3")
+
+    post1 = create(:post, body: "Hello @user2.")
+    entry1 = create(:entry, entryable: post1, owner: user1)
+
+    create(:mention, entry: entry1, mentioner: user1, mentionee: user2)
+
+    post2 = create(:post, body: "Hello.")
+    entry2 = create(:entry, entryable: post2, owner: user2)
+
+    create(:mention, entry: entry2, mentioner: user2, mentionee: user3)
+
+    assert_difference "Mention.count", -1 do
+      Entry::MentionCleaner.new(entry2).clean
+    end
+
+    assert_equal [ user2 ], entry1.mentions.reload.map(&:mentionee)
+    assert entry2.reload.mentions.none?
+  end
+end

--- a/test/models/entry/mention_importer_test.rb
+++ b/test/models/entry/mention_importer_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class Entry::MentionSyncerTest < ActiveSupport::TestCase
+class Entry::MentionImporterTest < ActiveSupport::TestCase
   test "creates new mentions" do
     user1 = create(:user, username: "user1")
     user2 = create(:user, username: "user2")
@@ -13,32 +13,10 @@ class Entry::MentionSyncerTest < ActiveSupport::TestCase
     entry = create(:entry, entryable: post, owner: user1)
 
     assert_difference "Mention.count", 2 do
-      Entry::MentionSyncer.new(entry).sync
+      Entry::MentionImporter.new(entry).import
     end
 
     assert_equal [ user2, user3 ], entry.mentions.map(&:mentionee)
-  end
-
-  test "destroys removed mentions" do
-    user1 = create(:user, username: "user1")
-    user2 = create(:user, username: "user2")
-    user3 = create(:user, username: "user3")
-
-    create(:follow, follower: user2, followee: user1)
-    create(:follow, follower: user3, followee: user1)
-
-    post = create(:post, body: "Hello @user2, @user3.")
-    entry = create(:entry, entryable: post, owner: user1)
-
-    Entry::MentionSyncer.new(entry).sync
-
-    post.update!(body: "Hello @user2.")
-
-    assert_difference "Mention.count", -1 do
-      Entry::MentionSyncer.new(entry.reload).sync
-    end
-
-    assert_equal [ user2 ], entry.mentions.map(&:mentionee)
   end
 
   test "does not create new mentions if the user is already mentioned" do
@@ -53,7 +31,7 @@ class Entry::MentionSyncerTest < ActiveSupport::TestCase
     create(:mention, entry:, mentioner: user1, mentionee: user2)
 
     assert_no_difference "Mention.count" do
-      Entry::MentionSyncer.new(entry).sync
+      Entry::MentionImporter.new(entry).import
     end
   end
 
@@ -67,41 +45,7 @@ class Entry::MentionSyncerTest < ActiveSupport::TestCase
     entry = create(:entry, entryable: post, owner: user1)
 
     assert_difference "Mention.count", 1 do
-      Entry::MentionSyncer.new(entry).sync
-    end
-  end
-
-  test "does not destroy unrelated mentions" do
-    user1 = create(:user, username: "user1")
-    user2 = create(:user, username: "user2")
-    user3 = create(:user, username: "user3")
-
-    create(:follow, follower: user2, followee: user1)
-
-    post = create(:post, body: "Hello @user2.")
-    entry = create(:entry, entryable: post, owner: user1)
-
-    create(:mention, entry:, mentioner: user1, mentionee: user3)
-
-    assert_no_difference "Mention.count" do
-      Entry::MentionSyncer.new(entry).sync
-    end
-  end
-
-  test "does not destroy mentions of other users" do
-    user1 = create(:user, username: "user1")
-    user2 = create(:user, username: "user2")
-    user3 = create(:user, username: "user3")
-
-    create(:follow, follower: user2, followee: user1)
-
-    post = create(:post, body: "Hello @user2.")
-    entry = create(:entry, entryable: post, owner: user1)
-
-    create(:mention, entry:, mentioner: user2, mentionee: user1)
-
-    assert_no_difference "Mention.count" do
-      Entry::MentionSyncer.new(entry).sync
+      Entry::MentionImporter.new(entry).import
     end
   end
 
@@ -112,7 +56,7 @@ class Entry::MentionSyncerTest < ActiveSupport::TestCase
     entry = create(:entry, entryable: post, owner: user1)
 
     assert_no_difference "Mention.count" do
-      Entry::MentionSyncer.new(entry).sync
+      Entry::MentionImporter.new(entry).import
     end
   end
 
@@ -127,7 +71,7 @@ class Entry::MentionSyncerTest < ActiveSupport::TestCase
     entry = create(:entry, entryable: post, owner: user1)
 
     assert_difference "Mention.count", 1 do
-      Entry::MentionSyncer.new(entry).sync
+      Entry::MentionImporter.new(entry).import
     end
 
     assert_equal [ user2 ], entry.mentions.map(&:mentionee)

--- a/test/models/entry/mention_syncer_test.rb
+++ b/test/models/entry/mention_syncer_test.rb
@@ -1,0 +1,121 @@
+require "test_helper"
+
+class Entry::MentionSyncerTest < ActiveSupport::TestCase
+  test "creates new mentions" do
+    user1 = create(:user, username: "user1")
+    user2 = create(:user, username: "user2")
+    user3 = create(:user, username: "user3")
+
+    create(:follow, follower: user2, followee: user1)
+    create(:follow, follower: user3, followee: user1)
+
+    post = create(:post, body: "Hello @user2, @user3.")
+    entry = create(:entry, entryable: post, owner: user1)
+
+    assert_difference "Mention.count", 2 do
+      Entry::MentionSyncer.new(entry).sync
+    end
+
+    assert_equal [ user2, user3 ], entry.mentions.map(&:mentionee)
+  end
+
+  test "destroys old mentions" do
+    user1 = create(:user, username: "user1")
+    user2 = create(:user, username: "user2")
+    user3 = create(:user, username: "user3")
+
+    create(:follow, follower: user2, followee: user1)
+    create(:follow, follower: user3, followee: user1)
+
+    post = create(:post, body: "Hello @user2, @user3.")
+    entry = create(:entry, entryable: post, owner: user1)
+
+    Entry::MentionSyncer.new(entry).sync
+
+    post.update!(body: "Hello @user2.")
+
+    assert_difference "Mention.count", -1 do
+      Entry::MentionSyncer.new(entry).sync
+    end
+
+    assert_equal [ user2 ], entry.mentions.map(&:mentionee)
+  end
+
+  test "does not create duplicated mentions" do
+    user1 = create(:user, username: "user1")
+    user2 = create(:user, username: "user2")
+
+    create(:follow, follower: user2, followee: user1)
+
+    post = create(:post, body: "Hello @user2.")
+    entry = create(:entry, entryable: post, owner: user1)
+
+    create(:mention, entry:, mentioner: user1, mentionee: user2)
+
+    assert_no_difference "Mention.count" do
+      Entry::MentionSyncer.new(entry).sync
+    end
+  end
+
+  test "does not destroy unrelated mentions" do
+    user1 = create(:user, username: "user1")
+    user2 = create(:user, username: "user2")
+    user3 = create(:user, username: "user3")
+
+    create(:follow, follower: user2, followee: user1)
+
+    post = create(:post, body: "Hello @user2.")
+    entry = create(:entry, entryable: post, owner: user1)
+
+    create(:mention, entry:, mentioner: user1, mentionee: user3)
+
+    assert_no_difference "Mention.count" do
+      Entry::MentionSyncer.new(entry).sync
+    end
+  end
+
+  test "does not destroy mentions of other users" do
+    user1 = create(:user, username: "user1")
+    user2 = create(:user, username: "user2")
+    user3 = create(:user, username: "user3")
+
+    create(:follow, follower: user2, followee: user1)
+
+    post = create(:post, body: "Hello @user2.")
+    entry = create(:entry, entryable: post, owner: user1)
+
+    create(:mention, entry:, mentioner: user2, mentionee: user1)
+
+    assert_no_difference "Mention.count" do
+      Entry::MentionSyncer.new(entry).sync
+    end
+  end
+
+  test "does not create mentions for non existent users" do
+    user1 = create(:user, username: "user1")
+
+    post = create(:post, body: "Hello @user2.")
+    entry = create(:entry, entryable: post, owner: user1)
+
+    assert_no_difference "Mention.count" do
+      Entry::MentionSyncer.new(entry).sync
+    end
+  end
+
+  test "can only mention followers" do
+    user1 = create(:user, username: "user1")
+    user2 = create(:user, username: "user2")
+    user3 = create(:user, username: "user3")
+
+    create(:follow, follower: user2, followee: user1)
+
+    post = create(:post, body: "Hello @user2, @user3.")
+    entry = create(:entry, entryable: post, owner: user1)
+
+    assert_difference "Mention.count", 1 do
+      Entry::MentionSyncer.new(entry).sync
+    end
+
+    assert_equal [ user2 ], entry.mentions.map(&:mentionee)
+  end
+end

--- a/test/models/entry_test.rb
+++ b/test/models/entry_test.rb
@@ -109,4 +109,17 @@ class EntryTest < ActiveSupport::TestCase
       entry.sync_mentions_later
     end
   end
+
+  test "mentioned_handles returns the usernames of the mentioned users" do
+    user1 = create(:user, username: "user1")
+    user2 = create(:user, username: "user2")
+
+    post = create(:post, body: "Hello @user1, @user2.")
+    entry = create(:entry, entryable: post)
+
+    create(:mention, entry:, mentionee: user1, mentioner: user1)
+    create(:mention, entry:, mentionee: user2, mentioner: user1)
+
+    assert_equal [ Handle.new("@user1"), Handle.new("@user2") ], entry.mentioned_handles
+  end
 end

--- a/test/models/entry_test.rb
+++ b/test/models/entry_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class EntryTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
   should belong_to(:owner)
 
   should have_many(:likes).dependent(:destroy)
@@ -98,5 +100,13 @@ class EntryTest < ActiveSupport::TestCase
     create(:entry_like, entry:, user:)
 
     assert_nil entry.like_for(nil)
+  end
+
+  test "sync_mentions_later enqueues a Entry::MentionSyncerJob" do
+    entry = create(:entry, :post)
+
+    assert_enqueued_with(job: Entry::MentionSyncerJob, args: [ entry ]) do
+      entry.sync_mentions_later
+    end
   end
 end

--- a/test/models/handle_text_parser_test.rb
+++ b/test/models/handle_text_parser_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+
+class HandleTextParserTest < ActiveSupport::TestCase
+  test "parses handles from text" do
+    text = "Hello @user, @user2."
+    handles = HandleTextParser.new(text).parse
+
+    assert_equal [ Handle.new("@user"), Handle.new("@user2") ], handles
+  end
+end

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -18,9 +18,9 @@ class PostTest < ActiveSupport::TestCase
     end
   end
 
-  test "mentioned_handles" do
+  test "extract_handles" do
     post = create(:post, body: "Hello @user, @user2.")
 
-    assert_equal [ Handle.new("@user"), Handle.new("@user2") ], post.mentioned_handles
+    assert_equal [ Handle.new("@user"), Handle.new("@user2") ], post.extract_handles
   end
 end

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -17,4 +17,10 @@ class PostTest < ActiveSupport::TestCase
       entry.post.destroy
     end
   end
+
+  test "mentioned_handles" do
+    post = create(:post, body: "Hello @user, @user2.")
+
+    assert_equal [ Handle.new("@user"), Handle.new("@user2") ], post.mentioned_handles
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -179,4 +179,42 @@ class UserTest < ActiveSupport::TestCase
     assert_equal Date.new(2025, 2, 1), progress_calendar.days.first.date
     assert_equal Date.new(2025, 4, 30), progress_calendar.days.last.date
   end
+
+  test "username is valid" do
+    %w[
+      test
+      abcd.abcd
+      1234
+      test.1234
+      ____
+    ].each do |username|
+      user = build(:user, username: username)
+
+      assert user.valid?
+    end
+  end
+
+  test "username cannot start with a dot" do
+    user = build(:user, username: ".test")
+
+    assert_not user.valid?
+  end
+
+  test "username cannot end with a dot" do
+    user = build(:user, username: "test.")
+
+    assert_not user.valid?
+  end
+
+  test "username cannot have two dots in a row" do
+    user = build(:user, username: "test..test")
+
+    assert_not user.valid?
+  end
+
+  test "username cannot have three dots in a row" do
+    user = build(:user, username: "test...test")
+
+    assert_not user.valid?
+  end
 end


### PR DESCRIPTION
Implementa o método `Entry#sync_mentions_later` que permite extrair e salvar menções feitas em posts e comentários. As menções são extraídas pela classe `HandleTextParser` e criadas no banco com a classe `Entry::MentionSyncer`.