### PR TITLE
feat: Add post show page

### DIFF
--- a/app/components/features/notifications/types/notification_like_component.html.erb
+++ b/app/components/features/notifications/types/notification_like_component.html.erb
@@ -3,7 +3,7 @@
 
   <div class="flex-1">
     <p class="font-semibold">
-      <%= user.name %> <%= t(".entry_#{entry_type}") %>
+      <%= user.name %> <%= t(".likes") %> <%= entry_link %>
     </p>
     <p class="text-xs text-zinc-500 dark:text-zinc-400 mt-2">
       <%= time_ago_in_words(record.created_at) + t(".ago") %>

--- a/app/components/features/notifications/types/notification_like_component.rb
+++ b/app/components/features/notifications/types/notification_like_component.rb
@@ -1,6 +1,15 @@
 module Notifications
   module Types
     class NotificationLikeComponent < ApplicationComponent
+      style :entry_link do
+        base do
+          %w[
+            underline text-primary-600 hover:text-primary-700
+            dark:text-primary-500 dark:hover:text-primary-400
+          ]
+        end
+      end
+
       def initialize(record:, **user_attrs)
         @record = record
         @user = record.user
@@ -14,6 +23,21 @@ module Notifications
       def entry_type
         record.entry.entryable_name
       end
+
+      def entry_path
+        polymorphic_path(record.entry.entryable)
+      end
+
+     def entry_link
+       link_to(
+         t(".entry_#{entry_type}"),
+         entry_path,
+         class: style(:entry_link),
+         data: {
+           turbo_stream: true
+         }
+       )
+     end
     end
   end
 end

--- a/app/components/ui/typography/component.rb
+++ b/app/components/ui/typography/component.rb
@@ -62,7 +62,7 @@ module UI
       end
 
       def call
-        content_tag(as, content, **default_attrs)
+        content_tag(as, content, **attrs)
       end
 
       def default_attrs

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,17 @@
 class PostsController < DashboardController
+  before_action :set_post, only: :show
+
   def new
     @post = Post.new
+  end
+
+  def show
+    authorize! @post
+
+    respond_to do |format|
+      format.html
+      format.turbo_stream
+    end
   end
 
   def create
@@ -16,5 +27,9 @@ class PostsController < DashboardController
   private
   def post_params
     params.require(:post).permit(:title, :body, images: [])
+  end
+
+  def set_post
+    @post = Post.find(params[:id])
   end
 end

--- a/app/policies/post_policy.rb
+++ b/app/policies/post_policy.rb
@@ -1,0 +1,26 @@
+class PostPolicy < ApplicationPolicy
+  pre_check :allow_owner
+
+  def show?
+    owner_has_public_profile? || follows_owner?
+  end
+
+  private
+  def allow_owner
+    allow! if owner?
+  end
+
+  def owner?
+    record.entry.owner_id == user&.id
+  end
+
+  def owner_has_public_profile?
+    record.entry.owner.public_profile?
+  end
+
+  def follows_owner?
+    return false if user.blank?
+
+    user.follows?(record.entry.owner)
+  end
+end

--- a/app/views/entries/entryables/_post.html.erb
+++ b/app/views/entries/entryables/_post.html.erb
@@ -17,7 +17,7 @@
       </div>
     </div>
 
-    <% if allowed_to?(:destroy?, entry) %>
+    <% if allowed_to?(:destroy?, entry) && destroy_entry_path.present? %>
       <div>
         <%= render UI::Dropdown::Component.new(alignment: :right) do |dropdown| %>
           <% dropdown.with_trigger do %>
@@ -47,7 +47,7 @@
         <%= post.title %>
       </p>
 
-      <%= entry.render_content.html_safe %>
+      <%= entry.render_content %>
 
       <% if post.goal_progress_change.present? %>
         <div class="flex items-center justify-start mt-2 lg:mt-4">

--- a/app/views/homes/show.html.erb
+++ b/app/views/homes/show.html.erb
@@ -50,7 +50,7 @@
               <p class="font-light text-zinc-600 font-heading text-sm dark:text-zinc-400">
                 <%= t(".goals") %>
               </p>
-              <p class="dark:text-white text-xl"><%= @goals.count %></p>
+              <p class="dark:text-white text-xl"><%= @user.goals.count %></p>
             </div>
           </div>
         </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,0 +1,13 @@
+<%= provide(:title, t(".title")) %>
+
+<div class="max-w-2xl mx-auto">
+  <%= render UI::Breadcrumb::Component.new do |breadcrumb| %>
+    <% breadcrumb.with_item(href: root_path) { t(".home") } %>
+    <% breadcrumb.with_separator %>
+    <% breadcrumb.with_item(active: true) { t(".page_title") } %>
+  <% end %>
+
+  <%= turbo_frame_tag :post, class: "block" do %>
+    <%= render partial: "entries/entryables/post", locals: { entry: @post.entry, destroy_entry_path: nil } %>
+  <% end %>
+</div>

--- a/app/views/posts/show.turbo_stream.erb
+++ b/app/views/posts/show.turbo_stream.erb
@@ -1,0 +1,58 @@
+<%= turbo_stream.update :modal do %>
+  <%= render UI::Modal::Component.new(
+    class: "w-full max-w-2xl bg-transparent dark:bg-transparent rounded-none text-left", 
+    open: true,
+    data: {
+      turbo_temporary: true
+    }
+  ) do |modal| %>
+    <%= turbo_frame_tag :post, src: post_path(@post), class: "w-full", loading: :lazy do %>
+      <%= render UI::Card::Component.new(class: "w-full") do |header| %>
+        <%= render UI::Card::HeaderComponent.new do |header| %>
+          <div class="flex items-center gap-2 mb-2">
+            <%= render UI::Skeleton::Component.new(class: "size-10") %>
+            <div>
+              <%= render UI::Skeleton::Component.new(class: "w-full max-w-32").with_content(
+                "User name",
+              ) %>
+
+              <div>
+                <%= render UI::Skeleton::Component.new.with_content(
+                  localize(Time.zone.now, format: :friendly),
+                ) %>
+              </div>
+            </div>
+          </div>
+        <% end %>
+        <%= render UI::Card::BodyComponent.new do |header| %>
+          <div class="flex flex-col">
+            <p class="h6">
+              <%= render UI::Skeleton::Component.new(class: "w-full max-w-48").with_content(
+                "Title",
+              ) %>
+            </p>
+
+            <div>
+              <% Array.new(5).each do %>
+                <%= render UI::Skeleton::Component.new(class: "w-full").with_content("Paragraph") %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+        <%= render UI::Card::ActionsComponent.new do %>
+          <div class="flex items-center">
+            <div class="flex-1 flex items-center gap-4">
+              <p class="text-sm text-zinc-500 font-normal dark:text-zinc-400">
+                <%= render UI::Skeleton::Component.new.with_content("1000 kudos") %>
+              </p>
+            </div>
+            <div class="flex items-center gap-2">
+              <%= render UI::Skeleton::Component.new(class: "size-7") %>
+              <%= render UI::Skeleton::Component.new(class: "size-7") %>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/registrations/_form.html.erb
+++ b/app/views/registrations/_form.html.erb
@@ -1,4 +1,4 @@
-<%= custom_form_with model: @user, url: registrations_path do |form| %>
+<%= custom_form_with model: @user, url: registrations_path, data: { turbo: false } do |form| %>
   <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
     <%= form.form_group :first_name do %>
       <%= form.label :first_name %>

--- a/app/views/sessions/_form.html.erb
+++ b/app/views/sessions/_form.html.erb
@@ -1,4 +1,4 @@
-<%= custom_form_with url: session_path do |form| %>
+<%= custom_form_with url: session_path, data: { turbo: false } do |form| %>
   <%= form.form_group :email_address do %>
     <%= form.label :email_address, t(".email_address") %>
     <%= form.email_field(

--- a/config/locales/pt-BR/features.yml
+++ b/config/locales/pt-BR/features.yml
@@ -21,8 +21,9 @@ pt-BR:
       types:
         notification_like_component:
           ago: " atrás"
-          entry_post: deu kudos em sua publicação
-          entry_comment: deu kudos em seu comentário
+          entry_post: em sua publicação
+          entry_comment: em seu comentário
+          likes: deu kudos
       list_component:
         empty_state_message: Você não possui notificações
         see_all: Ver todas as notificações

--- a/config/locales/pt-BR/views/posts.yml
+++ b/config/locales/pt-BR/views/posts.yml
@@ -5,6 +5,10 @@ pt-BR:
       title: Goals | Nova publicação
       page_title: Nova publicação
       submit: Criar publicação
+    show:
+      title: Goals | Publicação
+      page_title: Publicação
+      home: Painel
     create:
       success: Publicação criada com sucesso
     destroy:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,7 @@ Rails.application.routes.draw do
       end
     end
   end
-  resources :posts, only: %i[new create]
+  resources :posts, only: %i[new show create]
   resources :entries, only: %i[] do
     scope module: :entries do
       resources :likes, only: %i[index]

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -1,6 +1,9 @@
 require "test_helper"
+require "action_policy/test_helper"
 
 class PostsControllerTest < ActionDispatch::IntegrationTest
+  include ActionPolicy::TestHelper
+
   test "new" do
     user = create(:user)
 
@@ -8,6 +11,40 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
 
     get new_post_url
     assert_response :success
+  end
+
+  test "show" do
+    user = create(:user)
+    post = create(:post)
+    entry = create(:entry, entryable: post, owner: user)
+
+    sign_in user
+
+    get post_url(post)
+    assert_response :success
+  end
+
+  test "show returns success response for turbo stream format" do
+    user = create(:user)
+    post = create(:post)
+    entry = create(:entry, entryable: post, owner: user)
+
+    sign_in user
+
+    get post_url(post, format: :turbo_stream)
+    assert_response :success
+  end
+
+  test "show is authorized" do
+    user = create(:user)
+    post = create(:post)
+    entry = create(:entry, entryable: post, owner: user)
+
+    sign_in user
+
+    assert_authorized_to(:show?, post, with: PostPolicy) do
+      get post_url(post)
+    end
   end
 
   test "can create post" do

--- a/test/policies/post_policy_test.rb
+++ b/test/policies/post_policy_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+
+class PostPolicyTest < ActiveSupport::TestCase
+  test "show? returns true if user owns the post and their profile is private" do
+    user = create(:user, profile_visibility: :private)
+    post = create(:post)
+    entry = create(:entry, entryable: post, owner: user)
+
+    policy = PostPolicy.new(post, user:)
+
+    assert policy.apply(:show?)
+  end
+
+  test "show? returns false if the post owner's profile is private and the user does not follow them" do
+    user = create(:user)
+    post_owner = create(:user, profile_visibility: :private)
+    post = create(:post)
+    entry = create(:entry, entryable: post, owner: post_owner)
+
+    policy = PostPolicy.new(post, user:)
+
+    assert_not policy.apply(:show?)
+  end
+
+  test "show? returns true if the post owner's profile is private and the user follows them" do
+    user = create(:user)
+    post_owner = create(:user, profile_visibility: :private)
+    post = create(:post)
+    entry = create(:entry, entryable: post, owner: post_owner)
+    create(:follow, follower: user, followee: post_owner)
+
+    policy = PostPolicy.new(post, user:)
+
+    assert policy.apply(:show?)
+  end
+
+  test "show? returns true if the post owner's profile is public" do
+    user = create(:user)
+    post_owner = create(:user, profile_visibility: :public)
+    post = create(:post)
+    entry = create(:entry, entryable: post, owner: post_owner)
+
+    policy = PostPolicy.new(post, user:)
+
+    assert policy.apply(:show?)
+  end
+
+  test "show? returns false if the user is not logged in" do
+    post_owner = create(:user, profile_visibility: :private)
+    post = create(:post)
+    entry = create(:entry, entryable: post, owner: post_owner)
+
+    policy = PostPolicy.new(post, user: nil)
+
+    assert_not policy.apply(:show?)
+  end
+end


### PR DESCRIPTION
- Adiciona a página do post
- Atualiza o componente de notificação para redirecionar para os posts
- Corrige a contagem de metas que era mostrada na página principal (aparecia sempre 5 metas)

**Notificações:**
![image](https://github.com/user-attachments/assets/d7a8f3a7-cdab-451f-acbe-f94378accfab)

**Página da publicação:**
![image](https://github.com/user-attachments/assets/4af2d318-26fb-4554-a950-2e7adc8e367a)

**Demonstração:**
https://github.com/user-attachments/assets/f4315175-f2be-4110-9e43-4310c9b8034d


