### PR TITLE
refactor: Add a notification notifier

### DIFF
--- a/app/models/notification_factory.rb
+++ b/app/models/notification_factory.rb
@@ -1,0 +1,11 @@
+class NotificationFactory
+  def create_like_notification(entry_like:)
+    notifiable = Notification::Like.build(entry_like:)
+    Notification.build(notifiable:)
+  end
+
+  def create_comment_notification(entry:)
+    notifiable = Notification::Comment.build(entry:)
+    Notification.build(notifiable:)
+  end
+end

--- a/app/models/notification_notifier.rb
+++ b/app/models/notification_notifier.rb
@@ -1,0 +1,22 @@
+class NotificationNotifier
+  def initialize(notification_factory:)
+    @notification_factory = notification_factory
+  end
+
+  def notify_like(entry_like:)
+    deliver @notification_factory.create_like_notification(entry_like:)
+  end
+
+  def notify_comment(entry:)
+    deliver @notification_factory.create_comment_notification(entry:)
+  end
+
+  def self.with_default
+    new(notification_factory: NotificationFactory.new)
+  end
+
+  private
+  def deliver(notification)
+    notification.deliver_later if notification.save
+  end
+end

--- a/config/initializers/event_subscriber.rb
+++ b/config/initializers/event_subscriber.rb
@@ -1,17 +1,11 @@
 ActiveSupport::Notifications.subscribe "like.entry" do |event|
   Rails.logger.info "Received Entry::Like with id: #{event.payload.id}"
 
-  notifiable = Notification::Like.build(entry_like: event.payload)
-  notification = Notification.new(notifiable: notifiable)
-
-  notification.deliver_later if notification.save
+  NotificationNotifier.with_default.notify_like(entry_like: event.payload)
 end
 
 ActiveSupport::Notifications.subscribe "comment.entry" do |event|
   Rails.logger.info "Received Comment with id: #{event.payload.id}"
 
-  notifiable = Notification::Comment.build(entry: event.payload)
-  notification = Notification.new(notifiable: notifiable)
-
-  notification.deliver_later if notification.save
+  NotificationNotifier.with_default.notify_comment(entry: event.payload)
 end

--- a/test/models/notification_factory_test.rb
+++ b/test/models/notification_factory_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class NotificationFactoryTest < ActiveSupport::TestCase
+  test "builds a notification for a like event" do
+    entry_like = create(:entry_like)
+    notification = NotificationFactory.new.create_like_notification(entry_like:)
+
+    assert_equal "Notification::Like", notification.notifiable_type
+  end
+
+  test "builds a notification for a comment event" do
+    entry = create(:entry, :post)
+    notification = NotificationFactory.new.create_comment_notification(entry:)
+
+    assert_equal "Notification::Comment", notification.notifiable_type
+  end
+end

--- a/test/models/notification_notifier_test.rb
+++ b/test/models/notification_notifier_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class NotificationNotifierTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  test "enqueues a notification for a like event" do
+    entry_like = create(:entry_like)
+    notification = NotificationFactory.new.create_like_notification(entry_like:)
+    notifier = NotificationNotifier.new(notification_factory: NotificationFactory.new)
+
+    assert_enqueued_with(job: ::Notifications::SendNotificationsJob) do
+      notifier.notify_like(entry_like:)
+    end
+  end
+
+  test "creates a notification for a like event" do
+    entry_like = create(:entry_like)
+    notification = NotificationFactory.new.create_like_notification(entry_like:)
+    notifier = NotificationNotifier.new(notification_factory: NotificationFactory.new)
+
+    assert_difference("Notification.count", 1) do
+      notifier.notify_like(entry_like:)
+    end
+
+    assert_equal "Notification::Like", notification.notifiable_type
+  end
+
+  test "enqueues a notification for a comment event" do
+    entry = create(:entry, :post)
+    notification = NotificationFactory.new.create_comment_notification(entry:)
+    notifier = NotificationNotifier.new(notification_factory: NotificationFactory.new)
+
+    assert_enqueued_with(job: ::Notifications::SendNotificationsJob) do
+      notifier.notify_comment(entry:)
+    end
+  end
+
+  test "creates a notification for a comment event" do
+    entry = create(:entry, :post)
+    notification = NotificationFactory.new.create_comment_notification(entry:)
+    notifier = NotificationNotifier.new(notification_factory: NotificationFactory.new)
+
+    assert_difference("Notification.count", 1) do
+      notifier.notify_comment(entry:)
+    end
+
+    assert_equal "Notification::Comment", notification.notifiable_type
+  end
+end


### PR DESCRIPTION
- Adiciona a classe `NotificationFactory` para construir os diferentes tipos de notificações
- Adiciona a classe `NotificationNotifier` para criar e enviar notificações
- Atualiza `config/initializers/event_subscriber.rb` para utilizar as novas classes