### PR TITLE
refactor: Move tailwind merger to const

### DIFF
--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -4,8 +4,10 @@ class ApplicationComponent < ViewComponent::Base
 
   attr_reader :attrs
 
+  TAILWIND_MERGER = TailwindMerge::Merger.new.freeze
+
   def initialize(**user_attrs)
-    @attrs = AttributeMerger.new(default_attrs, user_attrs).merge
+    @attrs = AttributeMerger.merge(default_attrs, user_attrs)
 
     merge_tailwind_classes(attrs)
   end
@@ -22,6 +24,6 @@ class ApplicationComponent < ViewComponent::Base
   def merge_tailwind_classes(attributes)
     return unless attributes[:class].is_a?(String)
 
-    attributes[:class] = TailwindMerge::Merger.new.merge(attributes[:class])
+    attributes[:class] = TAILWIND_MERGER.merge(attributes[:class])
   end
 end

--- a/app/components/ui/card/media_component.rb
+++ b/app/components/ui/card/media_component.rb
@@ -22,7 +22,7 @@ module UI
 
       def initialize(src: nil, wrapper_attrs: {}, **user_attrs)
         @src = src
-        @wrapper_attrs = AttributeMerger.new(default_wrapper_attrs, wrapper_attrs).merge
+        @wrapper_attrs = AttributeMerger.merge(default_wrapper_attrs, wrapper_attrs)
 
         super(**user_attrs)
       end

--- a/app/components/ui/progress_bar/component.rb
+++ b/app/components/ui/progress_bar/component.rb
@@ -51,7 +51,7 @@ module UI
         @progress = progress.to_f.round(2)
         @color = color
         @size = size
-        @wrapper_attrs = AttributeMerger.new(default_wrapper_attrs, wrapper_attrs).merge
+        @wrapper_attrs = AttributeMerger.merge(default_wrapper_attrs, wrapper_attrs)
 
         super(**user_attrs)
       end

--- a/app/components/ui/toast/component.rb
+++ b/app/components/ui/toast/component.rb
@@ -49,7 +49,7 @@ module UI
       def initialize(placement: :top_right, color: :success, wrapper_attrs: {}, **user_attrs)
         @color = color
         @placement = placement
-        @wrapper_attrs = AttributeMerger.new(default_wrapper_attrs, wrapper_attrs).merge
+        @wrapper_attrs = AttributeMerger.merge(default_wrapper_attrs, wrapper_attrs)
 
         super(**user_attrs)
       end

--- a/test/components/attributes_merger_test.rb
+++ b/test/components/attributes_merger_test.rb
@@ -5,35 +5,27 @@ class AttributeMergerTest < ActiveSupport::TestCase
     default_attrs = { value: "a" }
     user_attrs = { value: "b" }
 
-    attribute_merger = AttributeMerger.new(default_attrs, user_attrs)
-
-    assert_equal ({ value: "a b" }), attribute_merger.merge
+    assert_equal ({ value: "a b" }), AttributeMerger.merge(default_attrs, user_attrs)
   end
 
   test "merges arrays" do
     default_attrs = { value: [ 1 ] }
     user_attrs = { value: [ 2 ] }
 
-    attribute_merger = AttributeMerger.new(default_attrs, user_attrs)
-
-    assert_equal ({ value: [ 1, 2 ] }), attribute_merger.merge
+    assert_equal ({ value: [ 1, 2 ] }), AttributeMerger.merge(default_attrs, user_attrs)
   end
 
   test "merges hashes" do
     default_attrs = { value: { value: "a" } }
     user_attrs = { value: { value: "b" } }
 
-    attribute_merger = AttributeMerger.new(default_attrs, user_attrs)
-
-    assert_equal ({ value: { value: "a b" } }), attribute_merger.merge
+    assert_equal ({ value: { value: "a b" } }), AttributeMerger.merge(default_attrs, user_attrs)
   end
 
   test "keeps user attributes when values don't match type" do
     default_attrs = { value: "a" }
     user_attrs = { value: 2 }
 
-    attribute_merger = AttributeMerger.new(default_attrs, user_attrs)
-
-    assert_equal ({ value: 2 }), attribute_merger.merge
+    assert_equal ({ value: 2 }), AttributeMerger.merge(default_attrs, user_attrs)
   end
 end


### PR DESCRIPTION
Move a inicialização do TailwindMerger para uma constante. Quando um componente é instanciado, uma instância do TailwindMerger é criada. Essa criação de objeto adiciona um overhead na renderização dos componentes.

## Benchmark

**Antes:**
![image](https://github.com/user-attachments/assets/f4e3904d-b73f-4c1e-a697-ad18035c534e)

**Depois:**
![image](https://github.com/user-attachments/assets/4885b335-b418-495e-915f-2957ae475067)

De `3.723k` iterações em 5 segundos para `3.519M`.

<details>
<summary>Script usado no benchmark</summary>

```ruby
require_relative 'config/environment'
require 'benchmark/ips'

class DummyComponent < ApplicationComponent
  def default_attrs
    { class: "bg-white text-black" }
  end
end

Benchmark.ips do |x|
  x.config(time: 5, warmup: 2)

  x.report("basic init") do
    DummyComponent.new
  end

  x.report("init with class") do
    DummyComponent.new(class: "bg-red-500 text-white")
  end

  x.report("init with mixed attrs") do
    DummyComponent.new(id: "main", data: { controller: "test" }, class: "p-2 m-4 text-sm")
  end

  x.compare!
end
```
</details>