### PR TITLE
feat: Remove notifications list cache

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -24,12 +24,10 @@
 
   <% if Current.user.present? %>
     <% header.with_item do %>
-      <% cache [:user_notifications, Current.user] do %>
-        <%= render Notifications::ListComponent.new(
-          user_notifications: Current.user.user_notifications.notification_center.limit(5), 
-          href: notifications_path
-        ) %>
-      <% end %>
+      <%= render Notifications::ListComponent.new(
+        user_notifications: Current.user.user_notifications.notification_center.limit(5), 
+        href: notifications_path
+      ) %>
     <% end %>
 
     <% header.with_item do %>


### PR DESCRIPTION
A central de notificações mostra o horário em que cada notificação foi recebida. O componente da lista de notificações estava envolvido em um bloco de cache, então o horário de recebimento das notificações não estava sendo atualizado. Este PR remove a cache do componente de listar as notificações.